### PR TITLE
update naming, moving gosnowth repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ of the methods, you can use the `godoc` tool to autogenerate the documentation
 shown below:
 
 ```bash
-godoc github.com/circonus/gosnowth # plaintext
-godoc -html github.com/circonus/gosnowth # html output
+godoc github.com/circonus-labs/gosnowth # plaintext
+godoc -html github.com/circonus-labs/gosnowth # html output
 ```
 
 ## Testing
@@ -21,7 +21,7 @@ godoc -html github.com/circonus/gosnowth # html output
 In order to test this package, run the go unit tests:
 
 ```bash
-go test github.com/circonus/gosnowth # run package unit tests
+go test github.com/circonus-labs/gosnowth # run package unit tests
 ```
 
 ## Using

--- a/cmd/example/retrieval.go
+++ b/cmd/example/retrieval.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/circonus/gosnowth"
+	"github.com/circonus-labs/gosnowth"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/cmd/example/state.go
+++ b/cmd/example/state.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/circonus/gosnowth"
+	"github.com/circonus-labs/gosnowth"
 )
 
 // ExampleGetNodeState - this example shows how you can get

--- a/cmd/example/submission.go
+++ b/cmd/example/submission.go
@@ -6,9 +6,8 @@ import (
 	"time"
 
 	"github.com/circonus-labs/circonusllhist"
+	"github.com/circonus-labs/gosnowth"
 	"github.com/satori/go.uuid"
-
-	"github.com/circonus/gosnowth"
 )
 
 // ExampleSubmitText - this example shows how you

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,7 @@
 // client for various operations.
 package main
 
-import "github.com/circonus/gosnowth/cmd/example"
+import "github.com/circonus-labs/gosnowth/cmd/example"
 
 func main() {
 	example.ExampleGetNodeState()


### PR DESCRIPTION
migration from github.com/circonus/gosnowth to github.com/circonus-labs/gosnowth