### PR TITLE
correction to the stream tag generation for rollup metric name, using…

### DIFF
--- a/rollup.go
+++ b/rollup.go
@@ -34,9 +34,11 @@ func (sc *SnowthClient) ReadRollupValues(
 
 	var metricBuilder strings.Builder
 	metricBuilder.WriteString(metric)
-	metricBuilder.WriteString("|ST[")
-	metricBuilder.WriteString(strings.Join(tags, ","))
-	metricBuilder.WriteString("]")
+	if len(tags) > 0 {
+		metricBuilder.WriteString("|ST[")
+		metricBuilder.WriteString(strings.Join(tags, ","))
+		metricBuilder.WriteString("]")
+	}
 
 	var (
 		r   = []RollupValues{}


### PR DESCRIPTION
… canonical name, but if tags are present in args, create the canonical name