### PR TITLE
Return error to the if no snowth nodes activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ directly through an exposed HTTP API documented in the IRONdb API documentation:
 
 https://github.com/circonus/irondb-docs/blob/master/api.md
 
-Each of the documented APIs are being implemented at methods of the SnowthClient
+Each of the documented APIs are being implemented as methods of the SnowthClient
 structure defined in this repository.  In order to see the documentation of each
 of the methods, you can use the `godoc` tool to autogenerate the documentation
 shown below:

--- a/client.go
+++ b/client.go
@@ -128,6 +128,7 @@ func NewSnowthClient(discover bool, addrs ...string) (*SnowthClient, error) {
 	// of that node, and populate the identifier and topology of that
 	// node.  Finally we will add the node and activate it.
 	sc.Logger.Info("initializing snowth client")
+	numActiveNodes := 0
 	for _, addr := range addrs {
 		url, err := url.Parse(addr)
 		if err != nil {
@@ -150,7 +151,13 @@ func NewSnowthClient(discover bool, addrs ...string) (*SnowthClient, error) {
 		sc.AddNodes(node)
 		sc.ActivateNodes(node)
 		sc.Logger.Debugf("activated node: %s -> %s", addr, state.Identity)
+		numActiveNodes++
 	}
+
+	if numActiveNodes == 0 {
+		return nil, errors.New("No snowth nodes could be activated")
+	}
+
 	// start a goroutine to watch for changes in state of the nodes,
 	// and manage the active/inactive lists accordingly
 	go sc.watchAndUpdate()

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,12 @@ import "testing"
 
 func TestNewSnowthClient(t *testing.T) {
 
+	// crude test to ensure err is returned for invalid snowth url
+	badAddr := "foobar"
+	_, err := NewSnowthClient(false, badAddr)
+	if err == nil {
+		t.Errorf("Error not encountered on invalid snowth addr %v", badAddr)
+	}
 }
 
 func TestIsNodeActive(t *testing.T) {


### PR DESCRIPTION
Previously the NewSnowthClient could return an empty set of snowth
nodes, which did not inform the caller that a largely useless struct was
returned.

Added crude unit test for this specific case. Additional tests should be
added for the client module.