### PR TITLE
Implement context and config for SnowthClient

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,9 +30,11 @@ type Config struct {
 }
 
 // NewConfig creates and initializes a new SnowthClient configuration value.
-func NewConfig() *Config {
+func NewConfig(servers ...string) *Config {
 	return &Config{
 		DialTimeout:   time.Duration(500 * time.Millisecond),
+		Discover:      false,
+		Servers:       servers,
 		Timeout:       time.Duration(10 * time.Second),
 		WatchInterval: time.Duration(30 * time.Second),
 	}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package gosnowth
 import (
 	"encoding/json"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,177 +11,220 @@ import (
 
 // Config values represent configuration information SnowthClient values.
 type Config struct {
-	// DialTimeout sets the initial connection timeout duration for attempt to
-	// connect to IRONdb. The default value is 500 milliseconds.
-	DialTimeout time.Duration
-
-	// Discover sets whether the client should attempt to discover other IRONdb
-	// nodes in the same cluster as the provided node servers.
-	Discover bool
-
-	// Servers is a list of IRONdb node servers to be used by a SnowthClient.
-	Servers []string
-
-	// Timeout sets the timeout duration for HTTP requests to IRONdb. The
-	// default value is 10 seconds.
-	Timeout time.Duration
-
-	// WatchInterval sets the frequency at which a SnowthClient will check for
-	// updates to the active status of its nodes if WatchAndUpdate() is called.
-	WatchInterval time.Duration
+	sync.RWMutex
+	dialTimeout   time.Duration
+	discover      bool
+	servers       []string
+	timeout       time.Duration
+	watchInterval time.Duration
 }
 
 // NewConfig creates and initializes a new SnowthClient configuration value.
-func NewConfig(servers ...string) *Config {
+func NewConfig(servers ...string) (*Config, error) {
 	c := &Config{
-		DialTimeout:   time.Duration(500 * time.Millisecond),
-		Discover:      false,
-		Servers:       []string{},
-		Timeout:       time.Duration(10 * time.Second),
-		WatchInterval: time.Duration(30 * time.Second),
+		dialTimeout:   time.Duration(500 * time.Millisecond),
+		discover:      false,
+		servers:       []string{},
+		timeout:       time.Duration(10 * time.Second),
+		watchInterval: time.Duration(30 * time.Second),
 	}
 
-	for _, svr := range servers {
-		if _, err := url.Parse(svr); err == nil {
-			c.Servers = append(c.Servers, svr)
-		}
+	if err := c.SetServers(servers...); err != nil {
+		return nil, err
 	}
 
-	return c
+	return c, nil
 }
 
 // MarshalJSON encodes a Config value into a JSON format byte slice.
 func (c *Config) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{}
-	if c.DialTimeout != 0 {
-		m["dial_timeout"] = c.DialTimeout.String()
+	c.RLock()
+	m := struct {
+		DialTimeout   string   `json:"dial_timeout,omitempty"`
+		Discover      bool     `json:"discover"`
+		Timeout       string   `json:"timeout,omitempty"`
+		WatchInterval string   `json:"watch_interval,omitempty"`
+		Servers       []string `json:"servers,omitempty"`
+	}{}
+
+	if c.dialTimeout != 0 {
+		m.DialTimeout = c.dialTimeout.String()
 	}
 
-	m["discover"] = c.Discover
-	if c.Timeout != 0 {
-		m["timeout"] = c.Timeout.String()
+	m.Discover = c.discover
+	if c.timeout != 0 {
+		m.Timeout = c.timeout.String()
 	}
 
-	if c.WatchInterval != 0 {
-		m["watch_interval"] = c.WatchInterval.String()
+	if c.watchInterval != 0 {
+		m.WatchInterval = c.watchInterval.String()
 	}
 
-	if len(c.Servers) > 0 {
-		m["servers"] = c.Servers
+	if len(c.servers) > 0 {
+		m.Servers = make([]string, len(c.servers))
+		copy(m.Servers, c.servers)
 	}
 
+	c.RUnlock()
 	return json.Marshal(m)
 }
 
 // UnmarshalJSON decodes a JSON format byte slice into the Config value.
 func (c *Config) UnmarshalJSON(b []byte) error {
-	m := map[string]interface{}{}
+	m := struct {
+		DialTimeout   string   `json:"dial_timeout,omitempty"`
+		Discover      bool     `json:"discover"`
+		Timeout       string   `json:"timeout,omitempty"`
+		WatchInterval string   `json:"watch_interval,omitempty"`
+		Servers       []string `json:"servers,omitempty"`
+	}{}
+
 	if err := json.Unmarshal(b, &m); err != nil {
 		return errors.Wrap(err, "unable to unmarshal JSON data")
 	}
 
-	if v, ok := m["dial_timeout"].(string); ok {
-		d, err := time.ParseDuration(v)
+	if m.DialTimeout != "" {
+		d, err := time.ParseDuration(m.DialTimeout)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse dial timeout")
 		}
 
-		if d < 0 || d > time.Minute {
-			return errors.New("invalid dial timeout value")
+		if err := c.SetDialTimeout(d); err != nil {
+			return err
 		}
-
-		c.DialTimeout = d
 	}
 
-	if v, ok := m["discover"].(bool); ok {
-		c.Discover = v
-	}
-
-	if v, ok := m["timeout"].(string); ok {
-		d, err := time.ParseDuration(v)
+	c.SetDiscover(m.Discover)
+	if m.Timeout != "" {
+		d, err := time.ParseDuration(m.Timeout)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse timeout")
 		}
 
-		if d < 0 || d > (5*time.Minute) {
-			return errors.New("invalid timeout value")
+		if err := c.SetTimeout(d); err != nil {
+			return err
 		}
-
-		c.Timeout = d
 	}
 
-	if v, ok := m["watch_interval"].(string); ok {
-		d, err := time.ParseDuration(v)
+	if m.WatchInterval != "" {
+		d, err := time.ParseDuration(m.WatchInterval)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse watch interval")
 		}
 
-		if d < 0 || d > (24*time.Hour) {
-			return errors.New("invalid watch interval value")
+		if err := c.SetWatchInterval(d); err != nil {
+			return err
 		}
-
-		c.WatchInterval = d
 	}
 
-	if v, ok := m["servers"].([]interface{}); ok {
-		for _, vv := range v {
-			if svr, ok := vv.(string); ok {
-				if _, err := url.Parse(svr); err == nil {
-					c.Servers = append(c.Servers, svr)
-				}
-			}
+	if len(m.Servers) > 0 {
+		if err := c.SetServers(m.Servers...); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-// WithDialTimeout sets a new dial timeout and returns a pointer to the updated
-// configuration value.
-func (c *Config) WithDialTimeout(t time.Duration) *Config {
-	if t >= 0 && t < time.Minute {
-		c.DialTimeout = t
+// DialTimeout gets the initial connection timeout duration for attempts to
+// connect to IRONdb. The default value is 500 milliseconds.
+func (c *Config) DialTimeout() time.Duration {
+	c.RLock()
+	defer c.RUnlock()
+	return c.dialTimeout
+}
+
+// SetDialTimeout sets a new dial timeout value.
+func (c *Config) SetDialTimeout(t time.Duration) error {
+	if t < 0 || t > time.Minute {
+		return errors.New("invalid dial timeout value")
 	}
 
-	return c
+	c.Lock()
+	c.dialTimeout = t
+	c.Unlock()
+	return nil
 }
 
-// WithDiscover sets a new discover value and returns a pointer to the updated
-// configuration value.
-func (c *Config) WithDiscover(d bool) *Config {
-	c.Discover = d
-	return c
+// Discover gets whether the client should attempt to discover other IRONdb
+// nodes in the same cluster as the provided node servers.
+func (c *Config) Discover() bool {
+	c.RLock()
+	defer c.RUnlock()
+	return c.discover
 }
 
-// WithTimeout sets a new timeout duration and returns a pointer to the updated
-// configuration value.
-func (c *Config) WithTimeout(t time.Duration) *Config {
-	if t >= 0 && t < (5*time.Minute) {
-		c.Timeout = t
+// SetDiscover sets whether the client should attempt to discover other IRONdb
+// nodes in the same cluster as the provided node servers.
+func (c *Config) SetDiscover(d bool) {
+	c.Lock()
+	c.discover = d
+	c.Unlock()
+}
+
+// Timeout gets the timeout duration for HTTP requests to IRONdb. The default
+// value is 10 seconds.
+func (c *Config) Timeout() time.Duration {
+	c.RLock()
+	defer c.RUnlock()
+	return c.timeout
+}
+
+// SetTimeout sets a new HTTP timeout duration.
+func (c *Config) SetTimeout(t time.Duration) error {
+	if t < 0 || t > (5*time.Minute) {
+		return errors.New("invalid timeout value")
 	}
 
-	return c
+	c.Lock()
+	c.timeout = t
+	c.Unlock()
+	return nil
 }
 
-// WithServers assigns a new list of servers and returns a pointer to the
+// Servers gets the list of IRONdb node servers to be used by a SnowthClient.
+func (c *Config) Servers() []string {
+	c.RLock()
+	defer c.RUnlock()
+	s := make([]string, len(c.servers))
+	copy(s, c.servers)
+	return s
+}
+
+// SetServers assigns a new list of server addressess and returns a pointer to the
 // updated configuration value.
-func (c *Config) WithServers(servers ...string) *Config {
-	c.Servers = []string{}
+func (c *Config) SetServers(servers ...string) error {
+	s := []string{}
 	for _, svr := range servers {
-		if _, err := url.Parse(svr); err == nil {
-			c.Servers = append(c.Servers, svr)
+		if _, err := url.Parse(svr); err != nil {
+			return errors.Wrap(err, "invalid server address "+svr)
 		}
+
+		s = append(s, svr)
 	}
 
-	return c
+	c.Lock()
+	c.servers = s
+	c.Unlock()
+	return nil
 }
 
-// WithWatchInterval sets a new interval for watch and update functionality and
-// returns a pointer to the updated configuration value.
-func (c *Config) WithWatchInterval(i time.Duration) *Config {
-	if i >= 0 && i <= (time.Hour*24) {
-		c.WatchInterval = i
+// WatchInterval gets the frequency at which a SnowthClient will check for
+// updates to the active status of its nodes if WatchAndUpdate() is called.
+func (c *Config) WatchInterval() time.Duration {
+	c.RLock()
+	defer c.RUnlock()
+	return c.watchInterval
+}
+
+// SetWatchInterval sets a new interval for watch and update functionality.
+func (c *Config) SetWatchInterval(i time.Duration) error {
+	if i < 0 || i > (time.Hour*24) {
+		return errors.New("invalid watch interval value")
 	}
 
-	return c
+	c.Lock()
+	c.watchInterval = i
+	c.Unlock()
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,142 @@
+package gosnowth
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Config values represent configuration information SnowthClient values.
+type Config struct {
+	// DialTimeout sets the initial connection timeout duration for attempt to
+	// connect to IRONdb. The default value is 500 milliseconds.
+	DialTimeout time.Duration
+
+	// Discover sets whether the client should attempt to discover other IRONdb
+	// nodes in the same cluster as the provided node servers.
+	Discover bool
+
+	// Servers is a list of IRONdb node servers to be used by a SnowthClient.
+	Servers []string
+
+	// Timeout sets the timeout duration for HTTP requests to IRONdb. The
+	// default value is 10 seconds.
+	Timeout time.Duration
+
+	// WatchInterval sets the frequency at which a SnowthClient will check for
+	// updates to the active status of its nodes if WatchAndUpdate() is called.
+	WatchInterval time.Duration
+}
+
+// NewConfig creates and initializes a new SnowthClient configuration value.
+func NewConfig() *Config {
+	return &Config{
+		DialTimeout:   time.Duration(500 * time.Millisecond),
+		Timeout:       time.Duration(10 * time.Second),
+		WatchInterval: time.Duration(30 * time.Second),
+	}
+}
+
+// MarshalJSON encodes a Config value into a JSON format byte slice.
+func (c *Config) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{}
+	if c.DialTimeout != 0 {
+		m["dial_timeout"] = c.DialTimeout.String()
+	}
+
+	m["discover"] = c.Discover
+	if c.Timeout != 0 {
+		m["timeout"] = c.Timeout.String()
+	}
+
+	if c.WatchInterval != 0 {
+		m["watch_interval"] = c.WatchInterval.String()
+	}
+
+	if len(c.Servers) > 0 {
+		m["servers"] = c.Servers
+	}
+
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into the Config value.
+func (c *Config) UnmarshalJSON(b []byte) error {
+	m := map[string]interface{}{}
+	var err error
+	if err = json.Unmarshal(b, &m); err != nil {
+		errors.Wrap(err, "unable to unmarshal JSON data")
+		return err
+	}
+
+	if v, ok := m["dial_timeout"].(string); ok {
+		c.DialTimeout, err = time.ParseDuration(v)
+		if err != nil {
+			return errors.Wrap(err, "unable to parse dial timeout")
+		}
+	}
+
+	if v, ok := m["discover"].(bool); ok {
+		c.Discover = v
+	}
+
+	if v, ok := m["timeout"].(string); ok {
+		c.Timeout, err = time.ParseDuration(v)
+		if err != nil {
+			return errors.Wrap(err, "unable to parse timeout")
+		}
+	}
+
+	if v, ok := m["watch_interval"].(string); ok {
+		c.WatchInterval, err = time.ParseDuration(v)
+		if err != nil {
+			return errors.Wrap(err, "unable to parse watch interval")
+		}
+	}
+
+	if v, ok := m["servers"].([]interface{}); ok {
+		for _, vv := range v {
+			if vs, ok := vv.(string); ok {
+				c.Servers = append(c.Servers, vs)
+			}
+		}
+	}
+
+	return nil
+}
+
+// WithDialTimeout sets a new dial timeout and returns a pointer to the updated
+// configuration value.
+func (c *Config) WithDialTimeout(t time.Duration) *Config {
+	c.DialTimeout = t
+	return c
+}
+
+// WithDiscover sets a new discover value and returns a pointer to the updated
+// configuration value.
+func (c *Config) WithDiscover(d bool) *Config {
+	c.Discover = d
+	return c
+}
+
+// WithTimeout sets a new timeout duration and returns a pointer to the updated
+// configuration value.
+func (c *Config) WithTimeout(t time.Duration) *Config {
+	c.Timeout = t
+	return c
+}
+
+// WithServers assigns a new list of servers and returns a pointer to the
+// updated configuration value.
+func (c *Config) WithServers(addrs ...string) *Config {
+	c.Servers = addrs
+	return c
+}
+
+// WithWatchInterval sets a new interval for watch and update functionality and
+// returns a pointer to the updated configuration value.
+func (c *Config) WithWatchInterval(i time.Duration) *Config {
+	c.WatchInterval = i
+	return c
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,69 @@
+package gosnowth
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewConfig(t *testing.T) {
+	cfg := NewConfig().
+		WithDialTimeout(time.Second).
+		WithDiscover(true).
+		WithServers("test1", "test2").
+		WithTimeout(time.Second).
+		WithWatchInterval(time.Second)
+	if cfg.DialTimeout != time.Second {
+		t.Errorf("Expected dial timeout: %v, got: %v",
+			time.Second, cfg.DialTimeout)
+	}
+
+	if cfg.Discover != true {
+		t.Errorf("Expected discover value: %v, got: %v",
+			true, cfg.Discover)
+	}
+
+	if len(cfg.Servers) != 2 {
+		t.Fatalf("Expected servers length: %v, got: %v",
+			2, len(cfg.Servers))
+	}
+
+	if cfg.Servers[0] != "test1" {
+		t.Errorf("Expected server value: %v, got: %v",
+			"test1", cfg.Servers[0])
+	}
+
+	if cfg.Servers[1] != "test2" {
+		t.Errorf("Expected server value: %v, got: %v",
+			"test2", cfg.Servers[1])
+	}
+
+	if cfg.Timeout != time.Second {
+		t.Errorf("Expected timeout: %v, got: %v",
+			time.Second, cfg.Timeout)
+	}
+
+	if cfg.WatchInterval != time.Second {
+		t.Errorf("Expected watch interval: %v, got: %v",
+			time.Second, cfg.WatchInterval)
+	}
+}
+
+func TestConfigMarshalJSON(t *testing.T) {
+	s := `{"dial_timeout":"100ms","discover":true,` +
+		`"servers":["localhost:8112"],"timeout":"1s","watch_interval":"5s"}`
+	c := NewConfig()
+	err := json.Unmarshal([]byte(s), c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(r) != s {
+		t.Errorf("Expected JSON string: %v, got: %v", s, string(r))
+	}
+}

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -13,9 +13,8 @@ import (
 // ExampleReadNNT demonstrates how to read NNT values from a given snowth node.
 func ExampleReadNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -61,9 +60,8 @@ func ExampleReadNNT() {
 // node.
 func ExampleReadText() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -85,14 +85,14 @@ func ExampleReadText() {
 			Offset: strconv.FormatInt(time.Now().Unix(), 10),
 			Value:  "a_text_data_value",
 		}); err != nil {
-			log.Printf("failed to write text data: %v", err)
+			log.Fatalf("failed to write text data: %v", err)
 		}
 
 		data, err := client.ReadTextValues(node,
 			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second),
 			id, "test-text-metric2")
 		if err != nil {
-			log.Printf("failed to read text data: %v", err)
+			log.Fatalf("failed to read text data: %v", err)
 		}
 
 		log.Printf("%+v\n", data)

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -13,8 +13,13 @@ import (
 // ExampleReadNNT demonstrates how to read NNT values from a given snowth node.
 func ExampleReadNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -60,8 +65,13 @@ func ExampleReadNNT() {
 // node.
 func ExampleReadText() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -13,7 +13,9 @@ import (
 // ExampleReadNNT demonstrates how to read NNT values from a given snowth node.
 func ExampleReadNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(false, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -59,7 +61,9 @@ func ExampleReadNNT() {
 // node.
 func ExampleReadText() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(false, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/state.go
+++ b/examples/state.go
@@ -10,7 +10,9 @@ import (
 // a particular node.
 func ExampleGetNodeState() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -29,7 +31,9 @@ func ExampleGetNodeState() {
 // ExampleGetNodeGossip demontrates how to get gossip details from a node.
 func ExampleGetNodeGossip() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -48,7 +52,9 @@ func ExampleGetNodeGossip() {
 // ExampleGetTopology demonstrates how to get topology details from a node.
 func ExampleGetTopology() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -68,7 +74,9 @@ func ExampleGetTopology() {
 // node.
 func ExampleGetTopoRing() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/state.go
+++ b/examples/state.go
@@ -10,9 +10,8 @@ import (
 // a particular node.
 func ExampleGetNodeState() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -31,9 +30,8 @@ func ExampleGetNodeState() {
 // ExampleGetNodeGossip demontrates how to get gossip details from a node.
 func ExampleGetNodeGossip() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -52,9 +50,8 @@ func ExampleGetNodeGossip() {
 // ExampleGetTopology demonstrates how to get topology details from a node.
 func ExampleGetTopology() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -74,9 +71,8 @@ func ExampleGetTopology() {
 // node.
 func ExampleGetTopoRing() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/state.go
+++ b/examples/state.go
@@ -10,8 +10,13 @@ import (
 // a particular node.
 func ExampleGetNodeState() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -30,8 +35,13 @@ func ExampleGetNodeState() {
 // ExampleGetNodeGossip demontrates how to get gossip details from a node.
 func ExampleGetNodeGossip() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -50,8 +60,13 @@ func ExampleGetNodeGossip() {
 // ExampleGetTopology demonstrates how to get topology details from a node.
 func ExampleGetTopology() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -71,8 +86,13 @@ func ExampleGetTopology() {
 // node.
 func ExampleGetTopoRing() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/state.go
+++ b/examples/state.go
@@ -25,7 +25,7 @@ func ExampleGetNodeState() {
 	for _, node := range client.ListActiveNodes() {
 		state, err := client.GetNodeState(node)
 		if err != nil {
-			log.Printf("failed to get state: %v", err)
+			log.Fatalf("failed to get state: %v", err)
 		}
 
 		log.Println(state)
@@ -101,7 +101,7 @@ func ExampleGetTopoRing() {
 	for _, node := range client.ListActiveNodes() {
 		tr, err := client.GetTopoRingInfo(node.GetCurrentTopology(), node)
 		if err != nil {
-			log.Printf("failed to get topology ring: %v", err)
+			log.Fatalf("failed to get topology ring: %v", err)
 		}
 
 		log.Println(tr)

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -14,7 +14,9 @@ import (
 // ExampleSubmitText demonstrates how to submit a text metric to a node.
 func ExampleSubmitText() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -37,7 +39,9 @@ func ExampleSubmitText() {
 // ExampleSubmitNNT demonstrates how to submit an NNT metric to a node.
 func ExampleSubmitNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -69,7 +73,9 @@ func ExampleSubmitNNT() {
 // ExampleSubmitHistogram demonstrates how to submit histogram data to a node.
 func ExampleSubmitHistogram() {
 	// Create a new client.
-	client, err := gosnowth.NewSnowthClient(true, SnowthServers...)
+	client, err := gosnowth.NewClient(gosnowth.NewConfig().
+		WithDiscover(true).
+		WithServers(SnowthServers...))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -35,7 +35,7 @@ func ExampleSubmitText() {
 			Offset: strconv.FormatInt(time.Now().Unix(), 10),
 			Value:  "a_text_data_value",
 		}); err != nil {
-			log.Printf("failed to write text data: %v", err)
+			log.Fatalf("failed to write text data: %v", err)
 		}
 	}
 }
@@ -73,7 +73,7 @@ func ExampleSubmitNNT() {
 				},
 			},
 		}); err != nil {
-			log.Printf("failed to write nnt data: %v", err)
+			log.Fatalf("failed to write nnt data: %v", err)
 		}
 	}
 }
@@ -105,13 +105,15 @@ func ExampleSubmitHistogram() {
 	for _, node := range client.ListActiveNodes() {
 		id := uuid.New().String()
 		if err := client.WriteHistogram(node, gosnowth.HistogramData{
-			Metric:    "test-text-metric2",
+			AccountID: 1,
+			Metric:    "test-hist-metric",
 			ID:        id,
+			CheckName: "test",
 			Offset:    time.Now().Unix(),
 			Histogram: hist,
 			Period:    60,
 		}); err != nil {
-			log.Printf("failed to write histogram data: %v", err)
+			log.Fatalf("failed to write histogram data: %v", err)
 		}
 	}
 }

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -14,9 +14,8 @@ import (
 // ExampleSubmitText demonstrates how to submit a text metric to a node.
 func ExampleSubmitText() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -39,9 +38,8 @@ func ExampleSubmitText() {
 // ExampleSubmitNNT demonstrates how to submit an NNT metric to a node.
 func ExampleSubmitNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -73,9 +71,8 @@ func ExampleSubmitNNT() {
 // ExampleSubmitHistogram demonstrates how to submit histogram data to a node.
 func ExampleSubmitHistogram() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig().
-		WithDiscover(true).
-		WithServers(SnowthServers...))
+	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
+		WithDiscover(true))
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -14,8 +14,13 @@ import (
 // ExampleSubmitText demonstrates how to submit a text metric to a node.
 func ExampleSubmitText() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -38,8 +43,13 @@ func ExampleSubmitText() {
 // ExampleSubmitNNT demonstrates how to submit an NNT metric to a node.
 func ExampleSubmitNNT() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -71,8 +81,13 @@ func ExampleSubmitNNT() {
 // ExampleSubmitHistogram demonstrates how to submit histogram data to a node.
 func ExampleSubmitHistogram() {
 	// Create a new client.
-	client, err := gosnowth.NewClient(gosnowth.NewConfig(SnowthServers...).
-		WithDiscover(true))
+	cfg, err := gosnowth.NewConfig(SnowthServers...)
+	if err != nil {
+		log.Fatalf("failed to create snowth configuration: %v", err)
+	}
+
+	cfg.SetDiscover(true)
+	client, err := gosnowth.NewClient(cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/circonus-labs/circonusllhist v0.1.3
-	github.com/google/uuid v1.1.0
+	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
-github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/gossip.go
+++ b/gossip.go
@@ -1,5 +1,7 @@
 package gosnowth
 
+import "context"
+
 // Gossip values contain gossip information from a node. This structure includes
 // information on how the nodes are communicating with each other, and if any
 // nodes are behind with each other with regards to data replication.
@@ -25,8 +27,13 @@ type GossipLatency map[string]string
 // as topology state, current and next topology.
 func (sc *SnowthClient) GetGossipInfo(
 	node *SnowthNode) (gossip *Gossip, err error) {
+	return sc.GetGossipInfoContext(context.Background(), node)
+}
+
+// GetGossipInfoContext is the context aware version of GetGossipInfo.
+func (sc *SnowthClient) GetGossipInfoContext(ctx context.Context,
+	node *SnowthNode) (gossip *Gossip, err error) {
 	gossip = new(Gossip)
-	err = sc.do(node, "GET", "/gossip/json", nil, gossip,
-		decodeJSON)
+	err = sc.do(ctx, node, "GET", "/gossip/json", nil, gossip, decodeJSON)
 	return
 }

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -2,10 +2,12 @@ package gosnowth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -170,5 +172,26 @@ func TestGetGossipInfo(t *testing.T) {
 	if (*res)[0].ID != "1f846f26-0cfd-4df5-b4f1-e0930604e577" {
 		t.Errorf("Expected ID: 1f846f26-0cfd-4df5-b4f1-e0930604e577, got: %v",
 			(*res)[0].ID)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	res, err = sc.GetGossipInfoContext(ctx, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res == nil || len(*res) != 4 {
+		t.Fatalf("Expected result length: 4, got: %v", len(*res))
+	}
+
+	if (*res)[0].ID != "1f846f26-0cfd-4df5-b4f1-e0930604e577" {
+		t.Errorf("Expected ID: 1f846f26-0cfd-4df5-b4f1-e0930604e577, got: %v",
+			(*res)[0].ID)
+	}
+
+	cancel()
+	res, err = sc.GetGossipInfoContext(ctx, node)
+	if err == nil || !strings.Contains(err.Error(), "context") {
+		t.Error("Expected context error.", err)
 	}
 }

--- a/histogram.go
+++ b/histogram.go
@@ -11,8 +11,10 @@ import (
 
 // HistogramData values represent histogram data records in IRONdb.
 type HistogramData struct {
+	AccountID int64                     `json:"account_id"`
 	Metric    string                    `json:"metric"`
 	ID        string                    `json:"id"`
+	CheckName string                    `json:"check_name"`
 	Offset    int64                     `json:"offset"`
 	Period    int64                     `json:"period"`
 	Histogram *circonusllhist.Histogram `json:"histogram"`

--- a/histogram.go
+++ b/histogram.go
@@ -2,6 +2,7 @@ package gosnowth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	"github.com/circonus-labs/circonusllhist"
@@ -20,13 +21,17 @@ type HistogramData struct {
 // WriteHistogram sends a variadic list of histogram data values to be written
 // to an IRONdb node.
 func (sc *SnowthClient) WriteHistogram(node *SnowthNode,
-	data ...HistogramData) (err error) {
+	data ...HistogramData) error {
+	return sc.WriteHistogramContext(context.Background(), node, data...)
+}
+
+// WriteHistogramContext is the context aware version of WriteHistogram.
+func (sc *SnowthClient) WriteHistogramContext(ctx context.Context,
+	node *SnowthNode, data ...HistogramData) error {
 	buf := new(bytes.Buffer)
-	enc := json.NewEncoder(buf)
-	if err := enc.Encode(data); err != nil {
+	if err := json.NewEncoder(buf).Encode(data); err != nil {
 		return errors.Wrap(err, "failed to encode HistogramData for write")
 	}
 
-	err = sc.do(node, "POST", "/histogram/write", buf, nil, nil)
-	return
+	return sc.do(ctx, node, "POST", "/histogram/write", buf, nil, nil)
 }

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -11,9 +11,11 @@ import (
 
 const histTestData = `[
 	{
-		"offset": 1408724400,
-		"id": "ae0f7f90-2a6b-481c-9cf5-21a31837020e",
+		"account_id": 1,
 		"metric": "example1",
+		"id": "ae0f7f90-2a6b-481c-9cf5-21a31837020e",
+		"check_name": "test",
+		"offset": 1408724400,
 		"period": 60,
 		"histogram": "AAA="
 	}

--- a/location.go
+++ b/location.go
@@ -1,14 +1,21 @@
 package gosnowth
 
 import (
+	"context"
 	"path"
 )
 
 // LocateMetric locates which nodes contain specified metric data.
 func (sc *SnowthClient) LocateMetric(uuid string, metric string,
 	node *SnowthNode) (location *Topology, err error) {
+	return sc.LocateMetricContext(context.Background(), uuid, metric, node)
+}
+
+// LocateMetricContext is the context aware version of LocateMetric.
+func (sc *SnowthClient) LocateMetricContext(ctx context.Context, uuid string,
+	metric string, node *SnowthNode) (location *Topology, err error) {
 	location = new(Topology)
-	err = sc.do(node, "GET", path.Join("/locate/xml", uuid, metric),
+	err = sc.do(ctx, node, "GET", path.Join("/locate/xml", uuid, metric),
 		nil, location, decodeXML)
 	return
 }

--- a/rollup.go
+++ b/rollup.go
@@ -1,6 +1,7 @@
 package gosnowth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -31,6 +32,14 @@ func (rv *RollupValues) UnmarshalJSON(b []byte) error {
 func (sc *SnowthClient) ReadRollupValues(
 	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
 	start, end time.Time) ([]RollupValues, error) {
+	return sc.ReadRollupValuesContext(context.Background(), node, id, metric,
+		tags, rollup, start, end)
+}
+
+// ReadRollupValuesContext is the context aware version of ReadRollupValues.
+func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
+	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
+	start, end time.Time) ([]RollupValues, error) {
 	startTS := start.Unix() - start.Unix()%int64(rollup/time.Second)
 	endTS := end.Unix() - end.Unix()%int64(rollup/time.Second) +
 		int64(rollup/time.Second)
@@ -43,7 +52,7 @@ func (sc *SnowthClient) ReadRollupValues(
 	}
 
 	r := []RollupValues{}
-	err := sc.do(node, "GET",
+	err := sc.do(ctx, node, "GET",
 		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds",
 			path.Join("/rollup", id,
 				url.QueryEscape(metricBuilder.String())),

--- a/state.go
+++ b/state.go
@@ -1,14 +1,21 @@
 package gosnowth
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 )
 
 // GetNodeState retrieves the state of an IRONdb node.
-func (sc *SnowthClient) GetNodeState(node *SnowthNode) (state *NodeState, err error) {
+func (sc *SnowthClient) GetNodeState(node *SnowthNode) (*NodeState, error) {
+	return sc.GetNodeStateContext(context.Background(), node)
+}
+
+// GetNodeStateContext is the context aware version of GetNodeState.
+func (sc *SnowthClient) GetNodeStateContext(ctx context.Context,
+	node *SnowthNode) (state *NodeState, err error) {
 	state = new(NodeState)
-	err = sc.do(node, "GET", "/state", nil, state, decodeJSON)
+	err = sc.do(ctx, node, "GET", "/state", nil, state, decodeJSON)
 	return
 }
 
@@ -114,7 +121,7 @@ type Features struct {
 	TextStore               bool `json:"text:store"`
 	HistogramStore          bool `json:"histogram:store"`
 	NNTSecondOrder          bool `json:"nnt:second_order"`
-	HistogramDynamicRollups bool `json:"hisogram:dynamic_rollups"`
+	HistogramDynamicRollups bool `json:"histogram:dynamic_rollups"`
 	NNTStore                bool `json:"nnt:store"`
 	FeatureFlags            bool `json:"features"`
 }

--- a/tags.go
+++ b/tags.go
@@ -1,6 +1,7 @@
 package gosnowth
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -18,6 +19,13 @@ type FindTagsItem struct {
 // FindTags retrieves metrics that are associated with the provided tag query.
 func (sc *SnowthClient) FindTags(node *SnowthNode, accountID int32,
 	query string, start, end string) ([]FindTagsItem, error) {
+	return sc.FindTagsContext(context.Background(), node, accountID, query,
+		start, end)
+}
+
+// FindTagsContext is the context aware version of FindTags.
+func (sc *SnowthClient) FindTagsContext(ctx context.Context, node *SnowthNode,
+	accountID int32, query string, start, end string) ([]FindTagsItem, error) {
 	u := fmt.Sprintf("%s?query=%s",
 		sc.getURL(node, fmt.Sprintf("/find/%d/tags", accountID)),
 		url.QueryEscape(query))
@@ -27,6 +35,6 @@ func (sc *SnowthClient) FindTags(node *SnowthNode, accountID int32,
 	}
 
 	r := []FindTagsItem{}
-	err := sc.do(node, "GET", u, nil, &r, decodeJSON)
+	err := sc.do(ctx, node, "GET", u, nil, &r, decodeJSON)
 	return r, err
 }

--- a/text.go
+++ b/text.go
@@ -2,6 +2,7 @@ package gosnowth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"path"
 	"strconv"
@@ -43,8 +44,16 @@ type TextValue struct {
 // ReadTextValues reads text data values from an IRONdb node.
 func (sc *SnowthClient) ReadTextValues(node *SnowthNode, start, end time.Time,
 	id, metric string) ([]TextValue, error) {
+	return sc.ReadTextValuesContext(context.Background(), node, start, end,
+		id, metric)
+}
+
+// ReadTextValuesContext is the context aware version of ReadTextValues.
+func (sc *SnowthClient) ReadTextValuesContext(ctx context.Context,
+	node *SnowthNode, start, end time.Time,
+	id, metric string) ([]TextValue, error) {
 	tvr := new(TextValueResponse)
-	err := sc.do(node, "GET", path.Join("/read",
+	err := sc.do(ctx, node, "GET", path.Join("/read",
 		strconv.FormatInt(start.Unix(), 10),
 		strconv.FormatInt(end.Unix(), 10), id, metric), nil, tvr, decodeJSON)
 	if tvr == nil {
@@ -64,10 +73,16 @@ type TextData struct {
 
 // WriteText writes text data to an IRONdb node.
 func (sc *SnowthClient) WriteText(node *SnowthNode, data ...TextData) error {
+	return sc.WriteTextContext(context.Background(), node, data...)
+}
+
+// WriteTextContext is the context aware version of WriteText.
+func (sc *SnowthClient) WriteTextContext(ctx context.Context, node *SnowthNode,
+	data ...TextData) error {
 	buf := new(bytes.Buffer)
 	if err := json.NewEncoder(buf).Encode(data); err != nil {
 		return errors.Wrap(err, "failed to encode TextData for write")
 	}
 
-	return sc.do(node, "POST", "/write/text", buf, nil, nil)
+	return sc.do(ctx, node, "POST", "/write/text", buf, nil, nil)
 }

--- a/topology.go
+++ b/topology.go
@@ -1,6 +1,7 @@
 package gosnowth
 
 import (
+	"context"
 	"encoding/xml"
 	"path"
 
@@ -28,8 +29,14 @@ type TopologyNode struct {
 
 // GetTopologyInfo retrieves topology information from a node.
 func (sc *SnowthClient) GetTopologyInfo(node *SnowthNode) (*Topology, error) {
+	return sc.GetTopologyInfoContext(context.Background(), node)
+}
+
+// GetTopologyInfoContext is the context aware version of GetTopologyInfo.
+func (sc *SnowthClient) GetTopologyInfoContext(ctx context.Context,
+	node *SnowthNode) (*Topology, error) {
 	t := new(Topology)
-	err := sc.do(node, "GET",
+	err := sc.do(ctx, node, "GET",
 		path.Join("/topology/xml", node.GetCurrentTopology()),
 		nil, t, decodeXML)
 	return t, err
@@ -38,15 +45,29 @@ func (sc *SnowthClient) GetTopologyInfo(node *SnowthNode) (*Topology, error) {
 // LoadTopology loads a new topology on a node without activating it.
 func (sc *SnowthClient) LoadTopology(hash string, t *Topology,
 	node *SnowthNode) error {
+	return sc.LoadTopologyContext(context.Background(), hash, t, node)
+}
+
+// LoadTopologyContext is the context aware version of LoadTopology.
+func (sc *SnowthClient) LoadTopologyContext(ctx context.Context, hash string,
+	t *Topology, node *SnowthNode) error {
 	b, err := encodeXML(t)
 	if err != nil {
 		return errors.Wrap(err, "failed to encode request data")
 	}
 
-	return sc.do(node, "POST", path.Join("/topology", hash), b, nil, nil)
+	return sc.do(ctx, node, "POST", path.Join("/topology", hash), b, nil, nil)
 }
 
-// ActivateTopology activates a new topology on the node. THIS IS DANGEROUS.
+// ActivateTopology activates a new topology on the node.
+// WARNING THIS IS DANGEROUS.
 func (sc *SnowthClient) ActivateTopology(hash string, node *SnowthNode) error {
-	return sc.do(node, "GET", path.Join("/activate", hash), nil, nil, nil)
+	return sc.ActivateTopologyContext(context.Background(), hash, node)
+}
+
+// ActivateTopologyContext is the context aware version of ActivateTopology.
+// WARNING THIS IS DANGEROUS.
+func (sc *SnowthClient) ActivateTopologyContext(ctx context.Context,
+	hash string, node *SnowthNode) error {
+	return sc.do(ctx, node, "GET", path.Join("/activate", hash), nil, nil, nil)
 }

--- a/toporing.go
+++ b/toporing.go
@@ -1,6 +1,7 @@
 package gosnowth
 
 import (
+	"context"
 	"encoding/xml"
 	"path"
 )
@@ -23,8 +24,14 @@ type TopoRingDetail struct {
 // GetTopoRingInfo retrieves topology ring information from a node.
 func (sc *SnowthClient) GetTopoRingInfo(hash string,
 	node *SnowthNode) (*TopoRing, error) {
+	return sc.GetTopoRingInfoContext(context.Background(), hash, node)
+}
+
+// GetTopoRingInfoContext is the context aware version of GetTopoRingInfo.
+func (sc *SnowthClient) GetTopoRingInfoContext(ctx context.Context,
+	hash string, node *SnowthNode) (*TopoRing, error) {
 	tr := new(TopoRing)
-	err := sc.do(node, "GET", path.Join("/toporing/xml", hash),
+	err := sc.do(ctx, node, "GET", path.Join("/toporing/xml", hash),
 		nil, tr, decodeXML)
 	return tr, err
 }


### PR DESCRIPTION
### This PR:

- Is completely backwards compatible with all previous versions of gosnowth. All changes introduced by this PR are non-breaking for any existing code using gosnowth.
- Introduces a Config type which allows creation of SnowthClient values with configurable properties. Values that can be set with configuration are:
  - DialTimeout sets a timeout value for the initial connection to an IRONdb server. Its default value is 500 milliseconds.
  - Discover sets whether or not the client should attempt to discover other IRONdb nodes using topology data retrieved from its provided servers. Its default value is false.
  - Servers sets the addresses of the IRONdb servers that should be used by the client.
  - Timeout sets a timeout value for the full duration of requests to IRONdb servers.  Its default value is 10 seconds.
  - WatchInterval sets the frequency at which the WatchAndUpdate() method checks for updates to the active status of the configured IRONdb nodes. Its default is 30 seconds.
- Implements context aware versions of all methods provided by SnowthClient.
  - These methods follow the standard library naming practice of appending 'Context' to the end of the name of the non-context aware method, and including a context.Context argument as the first parameter of the new method.
  - These methods all fully support context deadlines and cancellation, and the context value provided to them is attached to all requests sent to IRONdb and can be accessed in the functions provided via SetRequestFunc() using the r.Context() function.
- Includes unit tests for all new configuration and context functionality.
- Updates all dependencies to the newest versions.
- Adds account_id and check_name values to data written with SnowthClient.WriteHistogram().