### PR TITLE
Fix issue with watch interval timer

### DIFF
--- a/client.go
+++ b/client.go
@@ -283,45 +283,43 @@ func (sc *SnowthClient) isNodeActive(node *SnowthNode) bool {
 // will also cancel the operation if the context is cancelled or expired. If
 // context cancellation is not needed, nil can be passed as the argument.
 func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
-	start := time.Now()
 	go func() {
+		tick := time.NewTicker(sc.watchInterval)
 		done := false
 		for !done && sc.watchInterval > 0 {
 			select {
 			case <-ctx.Done():
 				done = true
 				break
-			default:
-				if !done && time.Since(start) > sc.watchInterval {
-					sc.LogDebugf("firing watch and update")
-					for _, node := range sc.ListInactiveNodes() {
-						sc.LogDebugf("checking node for inactive -> active: %s",
+			case <-tick.C:
+				sc.LogDebugf("firing watch and update")
+				for _, node := range sc.ListInactiveNodes() {
+					sc.LogDebugf("checking node for inactive -> active: %s",
+						node.GetURL().Host)
+					if sc.isNodeActive(node) {
+						// Move to active.
+						sc.LogDebugf("active, moving to active list: %s",
 							node.GetURL().Host)
-						if sc.isNodeActive(node) {
-							// Move to active.
-							sc.LogDebugf("active, moving to active list: %s",
-								node.GetURL().Host)
-							sc.ActivateNodes(node)
-						}
+						sc.ActivateNodes(node)
 					}
-
-					for _, node := range sc.ListActiveNodes() {
-						sc.LogDebugf("checking node for active -> inactive: %s",
-							node.GetURL().Host)
-						if !sc.isNodeActive(node) {
-							// Move to inactive.
-							sc.LogWarnf("inactive, moving to inactive list: %s",
-								node.GetURL().Host)
-							sc.DeactivateNodes(node)
-						}
-					}
-
-					start = time.Now()
-				} else {
-					runtime.Gosched()
 				}
+
+				for _, node := range sc.ListActiveNodes() {
+					sc.LogDebugf("checking node for active -> inactive: %s",
+						node.GetURL().Host)
+					if !sc.isNodeActive(node) {
+						// Move to inactive.
+						sc.LogWarnf("inactive, moving to inactive list: %s",
+							node.GetURL().Host)
+						sc.DeactivateNodes(node)
+					}
+				}
+			default:
+				runtime.Gosched()
 			}
 		}
+
+		tick.Stop()
 	}()
 }
 

--- a/client.go
+++ b/client.go
@@ -315,6 +315,8 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 							sc.DeactivateNodes(node)
 						}
 					}
+
+					start = time.Now()
 				} else {
 					runtime.Gosched()
 				}

--- a/client_test.go
+++ b/client_test.go
@@ -178,6 +178,9 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 	if !sc.isNodeActive(node) {
 		t.Errorf("Expected node to be active")
 	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
 }
 
 type mockLog struct {

--- a/client_test.go
+++ b/client_test.go
@@ -181,6 +181,8 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 
 	cancel()
 	time.Sleep(50 * time.Millisecond)
+	sc.watchInterval = 0
+	sc.WatchAndUpdate(ctx)
 }
 
 type mockLog struct {


### PR DESCRIPTION
### This PR:
- Fixes an issue with the SnowthClient.WatchAndUpdate() feature. It was not resetting the interval timer, resulting in node status polling continuously.  This change fixes the interval timing.