### PR TITLE
Add support for check_tags field used by FindTags()

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -8,12 +8,13 @@ import (
 
 // FindTagsItem values represent results returned from IRONdb tag queries.
 type FindTagsItem struct {
-	UUID       string
-	CheckName  string `json:"check_name"`
-	MetricName string `json:"metric_name"`
-	Category   string
-	Type       string
-	AccountID  int32 `json:"account_id"`
+	UUID       string   `json:"uuid"`
+	CheckName  string   `json:"check_name"`
+	CheckTags  []string `json:"check_tags,omitempty"`
+	MetricName string   `json:"metric_name"`
+	Category   string   `json:"category"`
+	Type       string   `type:"type"`
+	AccountID  int32    `json:"account_id"`
 }
 
 // FindTags retrieves metrics that are associated with the provided tag query.

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,6 +12,10 @@ const tagsTestData = `[
 	{
 		"uuid": "3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d",
 		"check_name": "test",
+		"check_tags": [
+			"test:test",
+			"__check_id:1"
+		],
 		"metric_name": "test",
 		"category": "reconnoiter",
 		"type": "numeric,histogram",
@@ -62,6 +66,14 @@ func TestFindTags(t *testing.T) {
 		t.Errorf("Expected metric name: test, got: %v", res[0].MetricName)
 	}
 
+	if len(res[0].CheckTags) != 2 {
+		t.Fatalf("Expected tags length: 2, got: %v", len(res[0].CheckTags))
+	}
+
+	if res[0].CheckTags[0] != "test:test" {
+		t.Errorf("Expected check tag: test:test, got: %v", res[0].CheckTags[0])
+	}
+
 	res, err = sc.FindTags(node, 1, "test", "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -77,5 +89,13 @@ func TestFindTags(t *testing.T) {
 
 	if res[0].MetricName != "test" {
 		t.Errorf("Expected metric name: test, got: %v", res[0].MetricName)
+	}
+
+	if len(res[0].CheckTags) != 2 {
+		t.Fatalf("Expected tags length: 2, got: %v", len(res[0].CheckTags))
+	}
+
+	if res[0].CheckTags[0] != "test:test" {
+		t.Errorf("Expected check tag: test:test, got: %v", res[0].CheckTags[0])
 	}
 }


### PR DESCRIPTION
### This PR:

- Implements support for the "check_tags" field contained in results returned from IRONdb queries using the `/find/<account>/tags` endpoint.
- This field contains information about the checks containing metric results, and additional user defined tag data about those checks.