### PR TITLE
Implement GetStats functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -326,9 +326,6 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 				return
 			case <-tick.C:
 				sc.LogDebugf("firing watch and update")
-				sc.RLock()
-				wf := sc.watch
-				sc.RUnlock()
 				for _, node := range sc.ListInactiveNodes() {
 					sc.LogDebugf("checking node for inactive -> active: %s",
 						node.GetURL().Host)
@@ -339,9 +336,12 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 						sc.ActivateNodes(node)
 					}
 
-					if wf != nil {
-						wf(node)
+					sc.RLock()
+					if sc.watch != nil {
+						sc.watch(node)
 					}
+
+					sc.RUnlock()
 				}
 
 				for _, node := range sc.ListActiveNodes() {
@@ -354,9 +354,12 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 						sc.DeactivateNodes(node)
 					}
 
-					if wf != nil {
-						wf(node)
+					sc.RLock()
+					if sc.watch != nil {
+						sc.watch(node)
 					}
+
+					sc.RUnlock()
 				}
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -326,6 +326,9 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 				return
 			case <-tick.C:
 				sc.LogDebugf("firing watch and update")
+				sc.RLock()
+				wf := sc.watch
+				sc.RUnlock()
 				for _, node := range sc.ListInactiveNodes() {
 					sc.LogDebugf("checking node for inactive -> active: %s",
 						node.GetURL().Host)
@@ -336,12 +339,9 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 						sc.ActivateNodes(node)
 					}
 
-					sc.RLock()
-					if sc.watch != nil {
-						sc.watch(node)
+					if wf != nil {
+						wf(node)
 					}
-
-					sc.RUnlock()
 				}
 
 				for _, node := range sc.ListActiveNodes() {
@@ -354,12 +354,9 @@ func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 						sc.DeactivateNodes(node)
 					}
 
-					sc.RLock()
-					if sc.watch != nil {
-						sc.watch(node)
+					if wf != nil {
+						wf(node)
 					}
-
-					sc.RUnlock()
 				}
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -53,6 +53,11 @@ func TestSnowthClientRequest(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
 			if r.Header.Get("X-Test-Header") != "test" {
 				t.Error("Expected X-Test-Header:test")
@@ -99,6 +104,11 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 		r *http.Request) {
 		if r.RequestURI == "/state" {
 			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -209,6 +219,11 @@ func TestSnowthClientLog(t *testing.T) {
 		r *http.Request) {
 		if r.RequestURI == "/state" {
 			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
 			return
 		}
 

--- a/client_test.go
+++ b/client_test.go
@@ -269,3 +269,55 @@ func TestSnowthClientLog(t *testing.T) {
 		t.Errorf("Expected log entry: %v, got: %v", exp, ml.last)
 	}
 }
+
+func TestSnowthClientSetWatch(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
+			if r.Header.Get("X-Test-Header") != "test" {
+				t.Error("Expected X-Test-Header:test")
+			}
+
+			w.Write([]byte(tagsTestData))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	sc.SetWatchInterval(100 * time.Millisecond)
+	sc.SetWatchFunc(func(n *SnowthNode) {
+		exp := "0.1.1570000000"
+		if n.SemVer() == exp {
+			sc.DeactivateNodes(n)
+		} else {
+			t.Errorf("Expected version: %v, got: %v", exp, n.SemVer())
+		}
+	})
+
+	nodes := sc.ListActiveNodes()
+	if len(nodes) < 1 {
+		t.Errorf("Expected length nodes > 1, got: %d", len(nodes))
+	}
+
+	sc.WatchAndUpdate(context.Background())
+	time.Sleep(150 * time.Millisecond)
+	nodes = sc.ListActiveNodes()
+	if len(nodes) > 0 {
+		t.Fatalf("Expected length nodes: 0, got: %d", len(nodes))
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -144,10 +144,9 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 	}
 
 	node := &SnowthNode{
-		url:        u,
-		identifier: "1f846f26-0cfd-4df5-b4f1-e0930604e577",
-		currentTopology: "0123456789abcdef0123456789abcdef0123456789abcdef" +
-			"0123456789abcdef",
+		url:             u,
+		identifier:      "bb6f7162-4828-11df-bab8-6bac200dcc2a",
+		currentTopology: "294cbd39999c2270964029691e8bc5e231a867d525ccba62181dc8988ff218dc",
 	}
 
 	res, err := sc.FindTags(node, 1, "test", "1", "1")

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -22,7 +22,7 @@ const gossipTestData = `[
 		"latency": {
 			"765ac4cc-1929-4642-9ef1-d194d08f9538": "0",
 			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0",
-			"07fa2237-5744-4c28-a622-a99cfc1ac87e": "0"
+			"bb6f7162-4828-11df-bab8-6bac200dcc2a": "0"
 		}
 	},
 	{
@@ -35,7 +35,7 @@ const gossipTestData = `[
 		"latency": {
 			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0",
 			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0",
-			"07fa2237-5744-4c28-a622-a99cfc1ac87e": "0"
+			"bb6f7162-4828-11df-bab8-6bac200dcc2a": "0"
 		}
 	},
 	{
@@ -48,11 +48,11 @@ const gossipTestData = `[
 		"latency": {
 			"765ac4cc-1929-4642-9ef1-d194d08f9538": "0",
 			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0",
-			"07fa2237-5744-4c28-a622-a99cfc1ac87e": "0"
+			"bb6f7162-4828-11df-bab8-6bac200dcc2a": "0"
 		}
 	},
 	{
-		"id": "07fa2237-5744-4c28-a622-a99cfc1ac87e",
+		"id": "bb6f7162-4828-11df-bab8-6bac200dcc2a",
 		"gossip_time": "1409082055.744880",
 		"gossip_age": "0.000000",
 		"topo_current": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -76,8 +76,7 @@ const gossipTestAltData = `[
 		"topo_state": "n/a",
 		"latency": {
 			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0",
-			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0",
-			"07fa2237-5744-4c28-a622-a99cfc1ac87e": "0"
+			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0"
 		}
 	},
 	{
@@ -89,12 +88,11 @@ const gossipTestAltData = `[
 		"topo_state": "n/a",
 		"latency": {
 			"765ac4cc-1929-4642-9ef1-d194d08f9538": "0",
-			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0",
-			"07fa2237-5744-4c28-a622-a99cfc1ac87e": "0"
+			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0"
 		}
 	},
 	{
-		"id": "07fa2237-5744-4c28-a622-a99cfc1ac87e",
+		"id": "1f846f26-0cfd-4df5-b4f1-e0930604e577",
 		"gossip_time": "1409082055.744880",
 		"gossip_age": "0.000000",
 		"topo_current": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -102,8 +100,7 @@ const gossipTestAltData = `[
 		"topo_state": "n/a",
 		"latency": {
 			"765ac4cc-1929-4642-9ef1-d194d08f9538": "0",
-			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0",
-			"1f846f26-0cfd-4df5-b4f1-e0930604e577": "0"
+			"8c2fc7b8-c569-402d-a393-db433fb267aa": "0"
 		}
 	}
 ]`

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -142,6 +142,11 @@ func TestGetGossipInfo(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if r.RequestURI == "/gossip/json" {
 			w.Write([]byte(gossipTestData))
 			return

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -29,6 +29,11 @@ func TestWriteHistogram(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if r.RequestURI == "/histogram/write" {
 			rb := []HistogramData{}
 			if err := json.NewDecoder(r.Body).Decode(&rb); err != nil {

--- a/location_test.go
+++ b/location_test.go
@@ -44,6 +44,11 @@ func TestLocateMetric(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI,
 			"/locate/xml/1f846f26-0cfd-4df5-b4f1-e0930604e577/test") {
 			w.Write([]byte(locateXMLTestData))

--- a/nnt_test.go
+++ b/nnt_test.go
@@ -131,6 +131,11 @@ func TestNNTReadWrite(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		u := "/read/1529509020/1529509200/1/" +
 			"fc85e0ab-f568-45e6-86ee-d7443be8277d/count/test"
 		if strings.HasPrefix(r.RequestURI, u) {

--- a/raw_test.go
+++ b/raw_test.go
@@ -19,6 +19,11 @@ func TestWriteRaw(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI, "/raw") {
 			b, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -70,6 +70,11 @@ func TestReadRollupValues(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		u := "/rollup/fc85e0ab-f568-45e6-86ee-d7443be8277d/" +
 			"online%7CST%5Btest%3Atest%5D?start_ts=1529509020" +
 			"&end_ts=1529509201&rollup_span=1s"

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,109 @@
+package gosnowth
+
+import (
+	"context"
+)
+
+// GetStats retrieves the metrics about the status of an IRONdb node.
+func (sc *SnowthClient) GetStats(node *SnowthNode) (*Stats, error) {
+	return sc.GetStatsContext(context.Background(), node)
+}
+
+// GetStatsContext is the context aware version of GetStats.
+func (sc *SnowthClient) GetStatsContext(ctx context.Context,
+	node *SnowthNode) (state *Stats, err error) {
+	state = new(Stats)
+	err = sc.do(ctx, node, "GET", "/stats.json", nil, state, decodeJSON)
+	return
+}
+
+// Stats values represent a collection of metric data describing the status
+// of an IRONdb node.
+type Stats map[string]interface{}
+
+// Identity returns the identity string value from a node state value.
+func (ns *Stats) Identity() string {
+	if ns == nil {
+		return ""
+	}
+
+	m, ok := (*ns)["identity"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	id, ok := m["_value"].(string)
+	if !ok {
+		return ""
+	}
+
+	return id
+}
+
+// SemVer returns the semantic version string value from a node state value.
+func (ns *Stats) SemVer() string {
+	if ns == nil {
+		return ""
+	}
+
+	m, ok := (*ns)["semver"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	ver, ok := m["_value"].(string)
+	if !ok {
+		return ""
+	}
+
+	return ver
+}
+
+// CurrentTopology returns the current topology string value from a node state
+// value.
+func (ns *Stats) CurrentTopology() string {
+	if ns == nil {
+		return ""
+	}
+
+	t, ok := (*ns)["topology"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	m, ok := t["current"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	current, ok := m["_value"].(string)
+	if !ok {
+		return ""
+	}
+
+	return current
+}
+
+// NextTopology returns the next topology string value from a node state value.
+func (ns *Stats) NextTopology() string {
+	if ns == nil {
+		return ""
+	}
+
+	t, ok := (*ns)["topology"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	m, ok := t["next"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	next, ok := m["_value"].(string)
+	if !ok {
+		return ""
+	}
+
+	return next
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,95 @@
+package gosnowth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const statsTestData = `{
+	"application": {
+		"_type": "s",
+		"_value": "snowth"
+	},
+	"identity": {
+		"_type": "s",
+		"_value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	},
+	"version": {
+		"_type": "s",
+		"_value": "test"
+	},
+	"topology": {
+		"next": {
+			"_type": "s",
+			"_value": "-"
+		},
+		"current": {
+			"_type": "s",
+			"_value": "test"
+		}
+	},
+	"semver": {
+		"_type": "s",
+		"_value": "0.1.1570000000"
+	}
+}`
+
+func TestGetStats(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
+			w.Write([]byte(tagsTestData))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.GetStats(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	if res.Identity() != exp {
+		t.Fatalf("Expected identity: %v, got: %v", exp, res.Identity())
+	}
+
+	exp = "0.1.1570000000"
+	if res.SemVer() != exp {
+		t.Fatalf("Expected version: %v, got: %v", exp, res.SemVer())
+	}
+
+	exp = "test"
+	if res.CurrentTopology() != exp {
+		t.Fatalf("Expected current: %v, got: %v", exp, res.CurrentTopology())
+	}
+
+	exp = "-"
+	if res.NextTopology() != exp {
+		t.Fatalf("Expected next: %v, got: %v", exp, res.NextTopology())
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -15,11 +15,11 @@ const statsTestData = `{
 	},
 	"identity": {
 		"_type": "s",
-		"_value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		"_value": "bb6f7162-4828-11df-bab8-6bac200dcc2a"
 	},
 	"version": {
 		"_type": "s",
-		"_value": "test"
+		"_value": "v52bcc96a9a1a41acd96352b9b63e59cba2b6a8a9\/65ab82cb7281e76e96b2fedafdc6594d50437d91"
 	},
 	"topology": {
 		"next": {
@@ -28,7 +28,7 @@ const statsTestData = `{
 		},
 		"current": {
 			"_type": "s",
-			"_value": "test"
+			"_value": "294cbd39999c2270964029691e8bc5e231a867d525ccba62181dc8988ff218dc"
 		}
 	},
 	"semver": {
@@ -73,23 +73,23 @@ func TestGetStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exp := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	exp := "bb6f7162-4828-11df-bab8-6bac200dcc2a"
 	if res.Identity() != exp {
-		t.Fatalf("Expected identity: %v, got: %v", exp, res.Identity())
+		t.Errorf("Expected identity: %v, got: %v", exp, res.Identity())
 	}
 
 	exp = "0.1.1570000000"
 	if res.SemVer() != exp {
-		t.Fatalf("Expected version: %v, got: %v", exp, res.SemVer())
+		t.Errorf("Expected version: %v, got: %v", exp, res.SemVer())
 	}
 
-	exp = "test"
+	exp = "294cbd39999c2270964029691e8bc5e231a867d525ccba62181dc8988ff218dc"
 	if res.CurrentTopology() != exp {
-		t.Fatalf("Expected current: %v, got: %v", exp, res.CurrentTopology())
+		t.Errorf("Expected current: %v, got: %v", exp, res.CurrentTopology())
 	}
 
 	exp = "-"
 	if res.NextTopology() != exp {
-		t.Fatalf("Expected next: %v, got: %v", exp, res.NextTopology())
+		t.Errorf("Expected next: %v, got: %v", exp, res.NextTopology())
 	}
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -31,6 +31,11 @@ func TestFindTags(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
 			w.Write([]byte(tagsTestData))
 			return

--- a/text_test.go
+++ b/text_test.go
@@ -27,6 +27,11 @@ func TestReadTextValues(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI,
 			"/read/1/2/3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d/test") {
 			w.Write([]byte(textTestData))
@@ -69,6 +74,11 @@ func TestWriteText(t *testing.T) {
 		r *http.Request) {
 		if r.RequestURI == "/state" {
 			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
 			return
 		}
 

--- a/topology_test.go
+++ b/topology_test.go
@@ -151,6 +151,11 @@ func TestTopology(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI,
 			"/topology/xml") {
 			w.Write([]byte(topologyXMLTestData))

--- a/toporing_test.go
+++ b/toporing_test.go
@@ -124,6 +124,11 @@ func TestGetTopoRingInfo(t *testing.T) {
 			return
 		}
 
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI,
 			"/toporing/xml/test") {
 			w.Write([]byte(topoRingXMLTestData))


### PR DESCRIPTION
- Implements SnowthClient.GetStats() functionality.  This retrieves metrics and stats data about an IRONdb node via the `/stats.json` API endpoint.
- The Stats type is defined to hold the metric data returned, and it stores the data in a `map[string]interface{}`, allowing the metrics exposed by IRONdb to change without breaking gosnowth.  But, helper methods are defined on the type to check and retrieve commonly used information.
- The code that creates and updates SnowthNode values has been changed to pull information via GetStats instead of GetState, so that additional information about the version of IRONdb running on a node can be obtained using the SnowthNode value.
- Adds an assignable middleware function that can run during the SnowthClient.WatchAndUpdate() process.
- This can enable downstream users of this library to implement feature gating based on the version of IRONdb that is being used.
- Adds tests for the GetStats() method, and updates existing tests to support these changes.
- This change adds an additional function to the existing gosnowth API, adds additional data to an existing type, and modifies some internal operations, but does not reduce or break the existing API in any way.