### PR TITLE
CIRC-3247: Add activity field to FindTagsItem data

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+### Added
+
+- A new field has been added to the FindTagsItem structure returned by calls to
+SnowthClient.FindTags(). The field is called Activity (JSON: `activity`), and
+contains the activity data returned by the IRONdb find tags API.
+
 ## [v1.2.0] - 2019-06-25
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -312,13 +312,14 @@ func (sc *SnowthClient) isNodeActive(node *SnowthNode) bool {
 // context cancellation is not needed, nil can be passed as the argument.
 func (sc *SnowthClient) WatchAndUpdate(ctx context.Context) {
 	sc.RLock()
-	defer sc.RUnlock()
-	if sc.watchInterval <= time.Duration(0) {
+	wi := sc.watchInterval
+	sc.RUnlock()
+	if wi <= time.Duration(0) {
 		return
 	}
 
 	go func() {
-		tick := time.NewTicker(sc.watchInterval)
+		tick := time.NewTicker(wi)
 		defer tick.Stop()
 		for {
 			select {

--- a/tags.go
+++ b/tags.go
@@ -8,13 +8,14 @@ import (
 
 // FindTagsItem values represent results returned from IRONdb tag queries.
 type FindTagsItem struct {
-	UUID       string   `json:"uuid"`
-	CheckName  string   `json:"check_name"`
-	CheckTags  []string `json:"check_tags,omitempty"`
-	MetricName string   `json:"metric_name"`
-	Category   string   `json:"category"`
-	Type       string   `type:"type"`
-	AccountID  int32    `json:"account_id"`
+	UUID       string    `json:"uuid"`
+	CheckName  string    `json:"check_name"`
+	CheckTags  []string  `json:"check_tags,omitempty"`
+	MetricName string    `json:"metric_name"`
+	Category   string    `json:"category"`
+	Type       string    `type:"type"`
+	AccountID  int32     `json:"account_id"`
+	Activity   [][]int32 `json:"activity,omitempty"`
 }
 
 // FindTags retrieves metrics that are associated with the provided tag query.

--- a/tags_test.go
+++ b/tags_test.go
@@ -19,6 +19,16 @@ const tagsTestData = `[
 		"metric_name": "test",
 		"category": "reconnoiter",
 		"type": "numeric,histogram",
+		"activity": [
+			[
+				1555610400,
+				1556588400
+			],
+			[
+				1556625600,
+				1561848300
+			]
+		],
 		"account_id": 1
 	}
 ]`
@@ -79,6 +89,20 @@ func TestFindTags(t *testing.T) {
 		t.Errorf("Expected check tag: test:test, got: %v", res[0].CheckTags[0])
 	}
 
+	if len(res[0].Activity) != 2 {
+		t.Fatalf("Expected activity length: 2, got %v", len(res[0].Activity))
+	}
+
+	if len(res[0].Activity[1]) != 2 {
+		t.Fatalf("Expected activity[1] length: 2, got %v",
+			len(res[0].Activity[1]))
+	}
+
+	if res[0].Activity[1][1] != 1561848300 {
+		t.Fatalf("Expected activity timestamp: 1561848300, got %v",
+			res[0].Activity[1][1])
+	}
+
 	res, err = sc.FindTags(node, 1, "test", "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -102,5 +126,19 @@ func TestFindTags(t *testing.T) {
 
 	if res[0].CheckTags[0] != "test:test" {
 		t.Errorf("Expected check tag: test:test, got: %v", res[0].CheckTags[0])
+	}
+
+	if len(res[0].Activity) != 2 {
+		t.Fatalf("Expected activity length: 2, got %v", len(res[0].Activity))
+	}
+
+	if len(res[0].Activity[1]) != 2 {
+		t.Fatalf("Expected activity[1] length: 2, got %v",
+			len(res[0].Activity[1]))
+	}
+
+	if res[0].Activity[1][1] != 1561848300 {
+		t.Fatalf("Expected activity timestamp: 1561848300, got %v",
+			res[0].Activity[1][1])
 	}
 }


### PR DESCRIPTION
- Adds an `activity` field to the FindTagsItem structure to capture this new data returned from the IRONdb API.
- Adds unit tests to verify the data returned from IRONdb deserializes correctly into the FindTagsItem structure.