### PR TITLE
CIRC-1572: Implement Lua extension APIs, DF4, CAQL

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.4.0] - 2019-09-15
+
 ### Added
 
 - Adds the FetchQuery type and the SnowthClient.FetchValues and
@@ -140,6 +142,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.4.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.4.0
 [v1.3.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.3.2
 [v1.3.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.3.1
 [v1.2.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,38 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+### Added
+
+- New functionality has been added to read histogram data using the SnowthClient
+ReadHistogramValues() and ReadHistogramValuesContext() methods. The new
+HistogramValue type has been added to represent the histogram data returned by
+the new methods.
+- New ReadRollupAllValues() and ReadRollupAllValuesContext() methods have been
+added to SnowthClient. These methods return slices of RollupAllValue values
+representing IRONdb rollup response data in the legacy / type=all format.
+- Adds new SnowthClient methods for listing Lua extensions and calling any Lua
+extension via the IRONdb extension APIs: SnowthClient.GetLuaExtensions() and
+SnowthClient.ExecLuaExtension().
+- Adds specific support for performing CAQL queries using the Lua extension with
+the SnowthClient.GetCAQLQuery() method.
+- Adds support for a Go data structure representation of the DF4 data format.
+This is needed to represent CAQL query results and will also allow for future
+support for IRONdb /fetch API requests.
+
+### Changed
+
+- The RollupValues type has been replaced by the RollupValue and RollupAllValue
+types. These types are better able to represent all possible rollup data formats
+that can be returned by IRONdb. This is an API breaking change that modifies the
+signature of the SnowthClient ReadRollupValues() and ReadRollupValuesContext()
+methods.
+- These new types allow true support for IRONdb formatted timestamps for rollup
+data retrieval methods by changing previous Timestamp integer field to a field
+named Time containing a Go time.Time value. This is translated to/from the
+IRONdb timestamp format during JSON encoding/decoding and the IRONdb timestamp
+can be retrieved (as as string) by calling the Timestamp() method on values of
+the new types.
+
 ## [v1.3.2] - 2019-08-26
 
 ### Changed
@@ -73,7 +105,8 @@ SnowthNode value.
 
 ### Added
 
-- Adds support for new check tags data returned from IRONdb to the SnowthClient.FindTags() methods.
+- Adds support for new check tags data returned from IRONdb to the
+SnowthClient.FindTags() methods.
 
 ## [v1.1.2] - 2019-03-13
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,9 @@ types. These types are better able to represent all possible rollup data formats
 that can be returned by IRONdb. This is an API breaking change that modifies the
 signature of the SnowthClient ReadRollupValues() and ReadRollupValuesContext()
 methods.
+- The SnowthClient ReadTextValues() and ReadTextValuesContext() have updated
+signatures to match the parameters of the other data retrieval methods. This is
+an API breaking change for these methods.
 - These new types allow true support for IRONdb formatted timestamps for rollup
 data retrieval methods by changing previous Timestamp integer field to a field
 named Time containing a Go time.Time value. This is translated to/from the

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ### Added
 
+- Adds the FetchQuery type and the SnowthClient.FetchValues and
+SnowthClient.FetchValuesContext() methods to support fetching data, in the DF4
+format, using the IRONdb /fetch API.
 - New functionality has been added to read histogram data using the SnowthClient
 ReadHistogramValues() and ReadHistogramValuesContext() methods. The new
 HistogramValue type has been added to represent the histogram data returned by

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -40,6 +40,8 @@ named Time containing a Go time.Time value. This is translated to/from the
 IRONdb timestamp format during JSON encoding/decoding and the IRONdb timestamp
 can be retrieved (as as string) by calling the Timestamp() method on values of
 the new types.
+- The new methods also support retrieving all types of rollup data. They are no
+longer restricted to only the average type data.
 
 ## [v1.3.2] - 2019-08-26
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # gosnowth
 
-## An IRONdb client package for Go programs
+## An IRONdb API client package for Go programs
 
-This codebase contains client code for accessing Snowth APIs.  IRONdb is deployed as a cluster of database nodes which can be queried directly through an exposed HTTP API.  For reference, see the the [IRONdb API Documentation](https://github.com/circonus/irondb-docs/blob/master/api.md).
+This codebase contains client code for accessing IRONdb API's. IRONdb is
+deployed as a cluster of database nodes which can be queried directly through
+an exposed HTTP API. For reference, see the the
+[IRONdb API Documentation](https://github.com/circonus/irondb-docs/blob/master/api.md).
 
 Each of the documented interfaces are implemented as methods of the SnowthClient
-structure defined in this repository.  Documentation for this package is available through the `go doc` tool using the following command:
+structure defined in this repository. Documentation for this package is
+available through the `go doc` tool using the following command:
 
 ``` bash
 go doc github.com/circonus-labs/gosnowth
@@ -21,7 +25,9 @@ go test -cover github.com/circonus-labs/gosnowth
 
 ## Using
 
-Examples of using this package are provided in the in the `/examples` sub-package which shows how to instantiate a new SnowthClient, as well as how to use the SnowthClient to perform operations on IRONdb nodes.
+Examples of using this package are provided in the in the `/examples` directory
+which shows how to instantiate a new SnowthClient value, as well as how to use
+the SnowthClient to perform operations on IRONdb nodes.
 
 To run the examples use the following command:
 
@@ -31,7 +37,7 @@ go run github.com/circonus-labs/gosnowth/examples <host:port> ...
 
 Where `<host:port> ...` is a list of one or more space separated IRONdb nodes.
 
-## IRONdb Clients
+## Other IRONdb Clients
 
-[Here](docs/SnowthClients.md) is a comparison of functionality between gosnowth and
-some other IRONdb client libraries.
+[Here](docs/SnowthClients.md) is a comparison of functionality between gosnowth
+and some other IRONdb client libraries.

--- a/caql.go
+++ b/caql.go
@@ -1,0 +1,59 @@
+package gosnowth
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// CAQLQuery values represent CAQL queries and associated parameters.
+type CAQLQuery struct {
+	Query   string
+	Start   int64
+	End     int64
+	Period  int64
+	Timeout int64
+}
+
+// GetCAQLQuery retrieves data values for metrics matching a CAQL format.
+func (sc *SnowthClient) GetCAQLQuery(node *SnowthNode, accountID int64,
+	q *CAQLQuery) (*DF4Response, error) {
+	return sc.GetCAQLQueryContext(context.Background(), node, accountID, q)
+}
+
+// GetCAQLQueryContext is the context aware version of GetCAQLQuery.
+func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context,
+	node *SnowthNode, accountID int64, q *CAQLQuery) (*DF4Response, error) {
+	u := sc.getURL(node, "/extension/lua/public/caql_v1") +
+		"?query=" + url.QueryEscape(q.Query)
+	if q.Start != 0 {
+		u += fmt.Sprintf("&start=%d", q.Start)
+	}
+
+	if q.End != 0 {
+		u += fmt.Sprintf("&end=%d", q.End)
+	}
+
+	if q.Period != 0 {
+		u += fmt.Sprintf("&period=%d", q.Period)
+	}
+
+	if q.Timeout != 0 {
+		u += fmt.Sprintf("&_timeout=%d", q.Timeout)
+	}
+
+	u += fmt.Sprintf("&format=DF4&account_id=%d", accountID)
+	r := &DF4Response{}
+	body, _, err := sc.do(ctx, node, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, err
+}

--- a/caql_test.go
+++ b/caql_test.go
@@ -1,0 +1,77 @@
+package gosnowth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGetCAQLQuery(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI,
+			"/extension/lua/public/caql_v1?query=test") {
+			w.Write([]byte(testDF4Response))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.GetCAQLQuery(node, 1, &CAQLQuery{
+		Query:  "test",
+		Start:  0,
+		End:    900,
+		Period: 300,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Head.Count != 3 {
+		t.Fatalf("Expected header count: 3, got: %v", res.Head.Count)
+	}
+
+	if len(res.Data) != 1 {
+		t.Fatalf("Expected data length: 1, got: %v", len(res.Data))
+	}
+
+	v, ok := res.Data[0][0].(float64)
+	if !ok {
+		t.Fatal("Unexpected data type")
+	}
+
+	if v != 1.0 {
+		t.Errorf("Expected value: 1, got: %v", v)
+	}
+
+	if len(res.Meta) != 1 {
+		t.Fatalf("Expected meta length: 1, got: %v", len(res.Meta))
+	}
+
+	if res.Meta[0].Label != "test" {
+		t.Errorf("Expected meta label: test, got: %v", res.Meta[0].Label)
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 type noOpReadCloser struct {
@@ -123,5 +124,45 @@ func TestEncodeXML(t *testing.T) {
 	b, _ := ioutil.ReadAll(reader)
 	if !strings.Contains(string(b), "somethingelse") {
 		t.Error("Should contain somethingelse")
+	}
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	tm := time.Unix(123456789, int64(time.Millisecond))
+	exp := "123456789.001"
+	res := formatTimestamp(tm)
+	if res != exp {
+		t.Errorf("Expected string: %v, got: %v", exp, res)
+	}
+
+	tm = time.Unix(123456789, 0)
+	exp = "123456789"
+	res = formatTimestamp(tm)
+	if res != exp {
+		t.Errorf("Expected string: %v, got: %v", exp, res)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	res, err := parseTimestamp("123456789.001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := time.Unix(123456789, int64(time.Millisecond))
+	if !res.Equal(exp) {
+		t.Errorf("Expected time: %v, got: %v", exp, res)
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	res, err := parseDuration("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := time.Second
+	if res != exp {
+		t.Errorf("Expected duration: %v, got: %v", exp, res)
 	}
 }

--- a/df4.go
+++ b/df4.go
@@ -2,10 +2,10 @@ package gosnowth
 
 // DF4Response values represent time series data in the DF4 format.
 type DF4Response struct {
-	Data [][]interface{} `json:"data,omitempty"`
-	Meta []DF4Meta       `json:"meta,omitempty"`
 	Ver  string          `json:"version,omitempty"`
 	Head DF4Head         `json:"head"`
+	Meta []DF4Meta       `json:"meta,omitempty"`
+	Data [][]interface{} `json:"data,omitempty"`
 }
 
 // DF4Meta values contain information and metadata about the metrics in a DF4

--- a/df4.go
+++ b/df4.go
@@ -1,0 +1,47 @@
+package gosnowth
+
+// DF4Response values represent time series data in the DF4 format.
+type DF4Response struct {
+	Data [][]interface{} `json:"data,omitempty"`
+	Meta []DF4Meta       `json:"meta,omitempty"`
+	Ver  string          `json:"version,omitempty"`
+	Head DF4Head         `json:"head"`
+}
+
+// DF4Meta values contain information and metadata about the metrics in a DF4
+// time series data response.
+type DF4Meta struct {
+	Kind  string   `json:"kind"`
+	Label string   `json:"label"`
+	Tags  []string `json:"tags,omitempty"`
+}
+
+// DF4Head values contain information about the time range of the data elements
+// in a DF4 time series data response.
+type DF4Head struct {
+	Count  int64 `json:"count"`
+	Start  int64 `json:"start"`
+	Period int64 `json:"period"`
+}
+
+// Copy returns a deep copy of the base DF4 response.
+func (dr *DF4Response) Copy() *DF4Response {
+	b := &DF4Response{
+		Data: make([][]interface{}, len(dr.Data)),
+		Meta: make([]DF4Meta, len(dr.Meta)),
+		Ver:  dr.Ver,
+		Head: DF4Head{
+			Count:  dr.Head.Count,
+			Start:  dr.Head.Start,
+			Period: dr.Head.Period,
+		},
+	}
+
+	copy(b.Meta, dr.Meta)
+	for i, v := range dr.Data {
+		b.Data[i] = make([]interface{}, len(v))
+		copy(b.Data[i], v)
+	}
+
+	return b
+}

--- a/df4_test.go
+++ b/df4_test.go
@@ -1,0 +1,118 @@
+package gosnowth
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testDF4Response = `{
+	"data": [
+		[
+			1,
+			2,
+			3
+		]
+	],
+	"meta": [
+		{
+			"kind": "numeric",
+			"label": "test",
+			"tags": [
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test"
+			]
+		}
+	],
+	"version": "DF4",
+	"head": {
+		"count": 3,
+		"start": 0,
+		"period": 300
+	}
+}`
+
+func TestDF4ResponseCopy(t *testing.T) {
+	var v *DF4Response
+	err := json.NewDecoder(bytes.NewBufferString(testDF4Response)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := v.Copy()
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1 := buf.String()
+	buf = &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s2 := buf.String()
+	if s1 != s2 {
+		t.Errorf("Expected JSON: %v, got: %v", s2, s1)
+	}
+}
+
+func TestMarshalDF4Response(t *testing.T) {
+	v := &DF4Response{
+		Data: [][]interface{}{{1, 2, 3}},
+		Meta: []DF4Meta{{
+			Tags: []string{
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test",
+			},
+			Label: "test",
+			Kind:  "numeric",
+		}},
+		Ver: "DF4",
+		Head: DF4Head{
+			Count:  3,
+			Start:  0,
+			Period: 300,
+		},
+	}
+
+	buf := &bytes.Buffer{}
+	err := json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := strings.Replace(strings.Replace(strings.Replace(testDF4Response,
+		"\n", "", -1), " ", "", -1), "\t", "", -1) + "\n"
+	if buf.String() != exp {
+		t.Errorf("Expected JSON: %s, got: %s", exp, buf.String())
+	}
+
+}
+
+func TestUnmarshalDF4Timeseries(t *testing.T) {
+	var v *DF4Response
+	err := json.NewDecoder(bytes.NewBufferString(testDF4Response)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v.Data) != 1 {
+		t.Fatalf(`Expected length: 1. got %d`, len(v.Data))
+	}
+
+	if v.Data[0][1] != 2.0 {
+		t.Errorf(`Expected value: 2.0. got %f`, v.Data[1][1])
+	}
+
+	if v.Head.Start != 0 {
+		t.Errorf(`Expected time start: 0. got %d`, v.Head.Start)
+	}
+
+	if v.Head.Period != 300 {
+		t.Errorf(`Expected time period: 300. got %d`, v.Head.Period)
+	}
+}

--- a/df4_test.go
+++ b/df4_test.go
@@ -8,13 +8,12 @@ import (
 )
 
 const testDF4Response = `{
-	"data": [
-		[
-			1,
-			2,
-			3
-		]
-	],
+	"version": "DF4",
+	"head": {
+		"count": 3,
+		"start": 0,
+		"period": 300
+	},
 	"meta": [
 		{
 			"kind": "numeric",
@@ -25,12 +24,13 @@ const testDF4Response = `{
 			]
 		}
 	],
-	"version": "DF4",
-	"head": {
-		"count": 3,
-		"start": 0,
-		"period": 300
-	}
+	"data": [
+		[
+			1,
+			2,
+			3
+		]
+	]
 }`
 
 func TestDF4ResponseCopy(t *testing.T) {

--- a/docs/SnowthClients.md
+++ b/docs/SnowthClients.md
@@ -25,6 +25,7 @@
 | Data Retrieval APIs | Retrieve Numeric Data | - | Yes (SnowthClient.ReadNNTAllValues & SnowthClient.ReadNNTValues) | Yes (Snowth::Fetcher::NNT) |
 |  | Retrieve Text Data | - | Yes (SnowthClient.ReadTextValues) | Yes (Snowth::Fetcher::Text) |
 |  | Retrieve Histogram Data | - | Yes (SnowthClient.ReadHistogramValues) | Yes (Snowth::Fetcher::Histogram) |
+|  | Perform Fetch API Calls | - | Yes (SnowthClient.FetchValues) | No |
 |  |  |  |  |  |
 | Data Deletion APIs | Delete Numeric for Metric/Check | - | No | No |
 |  | Delete Text for Metric/Check | - | No | No |

--- a/docs/SnowthClients.md
+++ b/docs/SnowthClients.md
@@ -1,6 +1,6 @@
 # Snowth Client Functionality
 
-| Category | Function | libsnowth | gosnowth (v1.1.3) | perl-snowth |
+| Category | Function | libsnowth | gosnowth | perl-snowth |
 |:---|:---|:---:|:---:|:---:|
 | Client Robustness | Ability to bootstrap nodes from single node | - | Yes (uses topology and gossip) | Yes (polls topology to isolate nodes) |
 |  | Ability to only use "working" nodes in event of failure | - | Yes (uses gossip data to determine health of nodes) | No |
@@ -24,14 +24,14 @@
 |  |  |  |  |  |
 | Data Retrieval APIs | Retrieve Numeric Data | - | Yes (SnowthClient.ReadNNTAllValues & SnowthClient.ReadNNTValues) | Yes (Snowth::Fetcher::NNT) |
 |  | Retrieve Text Data | - | Yes (SnowthClient.ReadTextValues) | Yes (Snowth::Fetcher::Text) |
-|  | Retrieve Histogram Data | - | No | Yes (Snowth::Fetcher::Histogram) |
+|  | Retrieve Histogram Data | - | Yes (SnowthClient.ReadHistogramValues) | Yes (Snowth::Fetcher::Histogram) |
 |  |  |  |  |  |
 | Data Deletion APIs | Delete Numeric for Metric/Check | - | No | No |
 |  | Delete Text for Metric/Check | - | No | No |
 |  | Delete Histogram for Metic/Check | - | No | No |
 |  | Delete all data prior to date | - | No | No |
 |  |  |  |  |  |
-| Lua Extensions API | Get List of Lua Extensions | - | No | No |
-|  | Execute a Lua Extension | - | No | No |
+| Lua Extensions API | Get List of Lua Extensions | - | Yes (SnowthClient.GetLuaExtensions) | No |
+|  | Execute a Lua Extension | - | Yes (SnowthClient.ExecLuaExtension) | No |
 
 \* Only works against the list of bootstrap nodes, until a state response is encountered, unable to target a specific node

--- a/fetch.go
+++ b/fetch.go
@@ -1,0 +1,149 @@
+package gosnowth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// FetchStream values represent queries for individual data streams in an
+// IRONdb fetch request.
+type FetchStream struct {
+	UUID            string   `json:"uuid"`
+	Name            string   `json:"name"`
+	Kind            string   `json:"kind"`
+	Label           string   `json:"label,omitempty"`
+	Transform       string   `json:"transform"`
+	TransformParams []string `json:"transform_params,omitempty"`
+}
+
+// FetchReduce values represent reduce operations to perform on specified
+// data streams in an IRONdb fetch request.
+type FetchReduce struct {
+	Label        string   `json:"label"`
+	Method       string   `json:"method"`
+	MethodParams []string `json:"method_params,omitempty"`
+}
+
+// FetchQuery values represent queries used to fetch IRONdb data.
+type FetchQuery struct {
+	Start   time.Time     `json:"start"`
+	Period  time.Duration `json:"period"`
+	Count   int64         `json:"count"`
+	Streams []FetchStream `json:"streams"`
+	Reduce  []FetchReduce `json:"reduce"`
+}
+
+// MarshalJSON encodes a FetchQuery value into a JSON format byte slice.
+func (fq *FetchQuery) MarshalJSON() ([]byte, error) {
+	v := struct {
+		Start   float64       `json:"start"`
+		Period  float64       `json:"period"`
+		Count   int64         `json:"count"`
+		Streams []FetchStream `json:"streams"`
+		Reduce  []FetchReduce `json:"reduce"`
+	}{}
+	fv, err := strconv.ParseFloat(formatTimestamp(fq.Start), 64)
+	if err != nil {
+		return nil, errors.New("invalid fetch start value: " +
+			formatTimestamp(fq.Start))
+	}
+
+	v.Start = fv
+	v.Period = fq.Period.Seconds()
+	v.Count = fq.Count
+	if len(fq.Streams) > 0 {
+		v.Streams = fq.Streams
+	}
+
+	if len(fq.Reduce) > 0 {
+		v.Reduce = fq.Reduce
+	}
+
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a HistogramValue value.
+func (fq *FetchQuery) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Start   float64       `json:"start"`
+		Period  float64       `json:"period"`
+		Count   int64         `json:"count"`
+		Streams []FetchStream `json:"streams"`
+		Reduce  []FetchReduce `json:"reduce"`
+	}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	if v.Start == 0 {
+		return errors.New("fetch query missing start: " + string(b))
+	}
+
+	fq.Start, err = parseTimestamp(strconv.FormatFloat(v.Start, 'f', 3, 64))
+	if err != nil {
+		return err
+	}
+
+	if v.Period == 0 {
+		return errors.New("fetch query missing period: " + string(b))
+	}
+
+	fq.Period = time.Duration(v.Period*1000) * time.Millisecond
+	if v.Count == 0 {
+		return errors.New("fetch query missing count: " + string(b))
+	}
+
+	fq.Count = v.Count
+	if len(v.Streams) < 1 {
+		return errors.New("fetch query requires at least one stream: " +
+			string(b))
+	}
+
+	fq.Streams = v.Streams
+	if len(v.Reduce) < 1 {
+		return errors.New("fetch query requires at least one reduce: " +
+			string(b))
+	}
+
+	fq.Reduce = v.Reduce
+	return nil
+}
+
+// Timestamp returns the FetchQuery start time as a string in the IRONdb
+// timestamp format.
+func (fq *FetchQuery) Timestamp() string {
+	return formatTimestamp(fq.Start)
+}
+
+// FetchValues retrieves data values using the IRONdb fetch API.
+func (sc *SnowthClient) FetchValues(node *SnowthNode,
+	q *FetchQuery) (*DF4Response, error) {
+	return sc.FetchValuesContext(context.Background(), node, q)
+}
+
+// FetchValuesContext is the context aware version of FetchValuesValues.
+func (sc *SnowthClient) FetchValuesContext(ctx context.Context,
+	node *SnowthNode, q *FetchQuery) (*DF4Response, error) {
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(&q); err != nil {
+		return nil, err
+	}
+
+	body, _, err := sc.do(ctx, node, "POST", "/fetch", buf)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &DF4Response{}
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, nil
+}

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -1,0 +1,130 @@
+package gosnowth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const fetchTestQuery = `{
+	"start":1555616700,
+	"period":300,
+	"count":10,
+	"streams":[
+		{
+			"uuid":"11223344-5566-7788-9900-aabbccddeeff",
+			"name":"test",
+			"kind":"numeric",
+			"label":"test",
+			"transform":"average"
+		}
+	],
+	"reduce": [{"label":"test","method":"test"}]
+}`
+
+func TestFetchQueryMarshaling(t *testing.T) {
+	v := &FetchQuery{}
+	err := json.NewDecoder(bytes.NewBufferString(fetchTestQuery)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Timestamp() != "1555616700" {
+		t.Errorf("Expected timestamp: 1555616700, got: %v", v.Timestamp())
+	}
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := strings.Replace(strings.Replace(strings.Replace(fetchTestQuery,
+		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	if buf.String() != exp {
+		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
+	}
+}
+
+func TestFetchQuery(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI,
+			"/fetch") {
+			w.Write([]byte(testDF4Response))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.FetchValues(node, &FetchQuery{
+		Start:  time.Unix(0, 0),
+		Period: 300 * time.Second,
+		Count:  3,
+		Streams: []FetchStream{{
+			UUID:      "11223344-5566-7788-9900-aabbccddeeff",
+			Name:      "test",
+			Kind:      "numeric",
+			Label:     "test",
+			Transform: "none",
+		}},
+		Reduce: []FetchReduce{{
+			Label:  "test",
+			Method: "average",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Head.Count != 3 {
+		t.Fatalf("Expected header count: 3, got: %v", res.Head.Count)
+	}
+
+	if len(res.Data) != 1 {
+		t.Fatalf("Expected data length: 1, got: %v", len(res.Data))
+	}
+
+	v, ok := res.Data[0][0].(float64)
+	if !ok {
+		t.Fatal("Unexpected data type")
+	}
+
+	if v != 1.0 {
+		t.Errorf("Expected value: 1, got: %v", v)
+	}
+
+	if len(res.Meta) != 1 {
+		t.Fatalf("Expected meta length: 1, got: %v", len(res.Meta))
+	}
+
+	if res.Meta[0].Label != "test" {
+		t.Errorf("Expected meta label: test, got: %v", res.Meta[0].Label)
+	}
+}

--- a/histogram.go
+++ b/histogram.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// HistogramValue values are individual data points of a rollup.
+// HistogramValue values are individual data points of a histogram metric.
 type HistogramValue struct {
 	Time   time.Time
 	Period time.Duration

--- a/histogram.go
+++ b/histogram.go
@@ -4,10 +4,119 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/circonus-labs/circonusllhist"
 	"github.com/pkg/errors"
 )
+
+// HistogramValue values are individual data points of a rollup.
+type HistogramValue struct {
+	Time   time.Time
+	Period time.Duration
+	Data   map[string]int64
+}
+
+// MarshalJSON encodes a HistogramValue value into a JSON format byte slice.
+func (hv *HistogramValue) MarshalJSON() ([]byte, error) {
+	v := []interface{}{}
+	tn := float64(0)
+	fv, err := strconv.ParseFloat(formatTimestamp(hv.Time), 64)
+	if err == nil {
+		tn = float64(fv)
+	}
+
+	v = append(v, tn)
+	v = append(v, hv.Period.Seconds())
+	v = append(v, hv.Data)
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a HistogramValue value.
+func (hv *HistogramValue) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	json.Unmarshal(b, &v)
+	if len(v) != 3 {
+		return fmt.Errorf("histogram value should contain three entries: %s",
+			string(b))
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		tv, err := parseTimestamp(strconv.FormatFloat(fv, 'f', 3, 64))
+		if err != nil {
+			return err
+		}
+
+		hv.Time = tv
+	}
+
+	if fv, ok := v[1].(float64); ok {
+		hv.Period = time.Duration(fv) * time.Second
+	}
+
+	if m, ok := v[2].(map[string]interface{}); ok {
+		hv.Data = make(map[string]int64, len(m))
+		for k, iv := range m {
+			if fv, ok := iv.(float64); ok {
+				hv.Data[k] = int64(fv)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Timestamp returns the HistogramValue time as a string in the IRONdb
+// timestamp format.
+func (hv *HistogramValue) Timestamp() string {
+	return formatTimestamp(hv.Time)
+}
+
+// ReadHistogramValues reads histogram data from a node.
+func (sc *SnowthClient) ReadHistogramValues(
+	node *SnowthNode, id, metric string, tags []string, period time.Duration,
+	start, end time.Time) ([]HistogramValue, error) {
+	return sc.ReadHistogramValuesContext(context.Background(), node, id, metric,
+		tags, period, start, end)
+}
+
+// ReadHistogramValuesContext is the context aware version of
+// ReadHistogramValues.
+func (sc *SnowthClient) ReadHistogramValuesContext(ctx context.Context,
+	node *SnowthNode, uuid, metric string, tags []string, period time.Duration,
+	start, end time.Time) ([]HistogramValue, error) {
+	startTS := start.Unix() - start.Unix()%int64(period.Seconds())
+	endTS := end.Unix() - end.Unix()%int64(period.Seconds()) +
+		int64(period.Seconds())
+	var metricBuilder strings.Builder
+	metricBuilder.WriteString(metric)
+	if len(tags) > 0 {
+		metricBuilder.WriteString("|ST[")
+		metricBuilder.WriteString(strings.Join(tags, ","))
+		metricBuilder.WriteString("]")
+	}
+
+	r := []HistogramValue{}
+	body, _, err := sc.do(ctx, node, "GET",
+		path.Join("/histogram", strconv.FormatInt(startTS, 10),
+			strconv.FormatInt(endTS, 10),
+			strconv.FormatInt(int64(period.Seconds()), 10), uuid,
+			url.QueryEscape(metricBuilder.String())), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, nil
+}
 
 // HistogramData values represent histogram data records in IRONdb.
 type HistogramData struct {

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -3,7 +3,6 @@ package gosnowth
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -94,10 +93,8 @@ func TestReadHistogramValues(t *testing.T) {
 			return
 		}
 
-		fmt.Println(r.RequestURI)
 		u := "/histogram/1556290800/1556291400/300/" +
-			"ae0f7f90-2a6b-481c-9cf5-21a31837020e/" +
-			"example1%7CST%5Btest%3Atest%5D"
+			"ae0f7f90-2a6b-481c-9cf5-21a31837020e/example1"
 		if strings.HasPrefix(r.RequestURI, u) {
 			w.Write([]byte(histogramTestData))
 			return
@@ -118,7 +115,7 @@ func TestReadHistogramValues(t *testing.T) {
 	node := &SnowthNode{url: u}
 	res, err := sc.ReadHistogramValues(node,
 		"ae0f7f90-2a6b-481c-9cf5-21a31837020e", "example1",
-		[]string{"test:test"}, 300*time.Second, time.Unix(1556290800, 0),
+		300*time.Second, time.Unix(1556290800, 0),
 		time.Unix(1556291200, 0))
 	if err != nil {
 		t.Fatal(err)

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -3,11 +3,35 @@ package gosnowth
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
+
+const histogramTestData = `[
+	[
+	  1556290800,
+	  300,
+	  {
+		"+23e-004": 1,
+		"+85e-004": 1
+	  }
+	],
+	[
+	  1556291100,
+	  300,
+	  {
+		"+22e-004": 1,
+		"+23e-004": 2,
+		"+30e-004": 1,
+		"+39e-003": 1
+	  }
+	]
+]`
 
 const histTestData = `[
 	{
@@ -20,6 +44,102 @@ const histTestData = `[
 		"histogram": "AAA="
 	}
 ]`
+
+func TestHistogramValueMarshaling(t *testing.T) {
+	v := []HistogramValue{}
+	err := json.NewDecoder(bytes.NewBufferString(histogramTestData)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v) != 2 {
+		t.Fatalf("Expected length: 2, got %v", len(v))
+	}
+
+	if v[0].Timestamp() != "1556290800" {
+		t.Errorf("Expected timestamp: 1556290800, got: %v", v[0].Timestamp())
+	}
+
+	if v[0].Period.Seconds() != 300.0 {
+		t.Errorf("Expected seconds: 300, got: %v", v[0].Period.Seconds())
+	}
+
+	if v[0].Data["+23e-004"] != 1 {
+		t.Errorf("Expected data: 1, got: %v", v[0].Data["+23e-004"])
+	}
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := strings.Replace(strings.Replace(strings.Replace(histogramTestData,
+		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	if buf.String() != exp {
+		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
+	}
+}
+
+func TestReadHistogramValues(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		fmt.Println(r.RequestURI)
+		u := "/histogram/1556290800/1556291400/300/" +
+			"ae0f7f90-2a6b-481c-9cf5-21a31837020e/" +
+			"example1%7CST%5Btest%3Atest%5D"
+		if strings.HasPrefix(r.RequestURI, u) {
+			w.Write([]byte(histogramTestData))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.ReadHistogramValues(node,
+		"ae0f7f90-2a6b-481c-9cf5-21a31837020e", "example1",
+		[]string{"test:test"}, 300*time.Second, time.Unix(1556290800, 0),
+		time.Unix(1556291200, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 2 {
+		t.Fatalf("Expected length: 1, got: %v", len(res))
+	}
+
+	if res[0].Timestamp() != "1556290800" {
+		t.Errorf("Expected timestamp: 1556290800, got: %v", res[0].Timestamp())
+	}
+
+	if res[0].Period.Seconds() != 300.0 {
+		t.Errorf("Expected seconds: 300, got: %v", res[0].Period.Seconds())
+	}
+
+	if res[0].Data["+23e-004"] != 1 {
+		t.Errorf("Expected data: 1, got: %v", res[0].Data["+23e-004"])
+	}
+}
 
 func TestWriteHistogram(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,

--- a/lua.go
+++ b/lua.go
@@ -1,0 +1,189 @@
+package gosnowth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// ExtensionParam values contain information about an extension parameter.
+type ExtensionParam struct {
+	Type        string      `json:"type"`
+	Optional    bool        `json:"optional"`
+	Default     interface{} `json:"default,omitempty"`
+	Description string      `json:"description,omitempty"`
+	AliasList   []string    `json:"alias_list,omitempty"`
+	Name        string      `json:"name,omitempty"`
+}
+
+// LuaExtension values contain information about a Lua extension.
+type LuaExtension struct {
+	Documentation    string                     `json:"documentation,omitempty"`
+	Method           string                     `json:"method"`
+	ParseJSONPayload bool                       `json:"PARSE_JSON_PAYLOAD,omitempty"`
+	Params           map[string]*ExtensionParam `json:"params"`
+	Man              string                     `json:"man,omitempty"`
+	Name             string                     `json:"name,omitempty"`
+	Description      string                     `json:"description"`
+}
+
+// LuaExtensions is a map of information about Lua extensions.
+type LuaExtensions map[string]*LuaExtension
+
+// UnmarshalJSON decodes a byte slice of JSON data into a LuaExtensions map.
+func (le *LuaExtensions) UnmarshalJSON(b []byte) error {
+	r := map[string]interface{}{}
+	err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&r)
+	if err != nil {
+		return err
+	}
+
+	*le = make(map[string]*LuaExtension, len(r))
+	for k, ext := range r {
+		(*le)[k] = &LuaExtension{Name: k}
+		if v, ok := ext.(map[string]interface{}); ok {
+			for key, val := range v {
+				switch key {
+				case "documentation":
+					if value, ok := val.(string); ok {
+						(*le)[k].Documentation = value
+					}
+				case "method":
+					if value, ok := val.(string); ok {
+						(*le)[k].Method = value
+					}
+				case "PARSE_JSON_PAYLOAD":
+					if value, ok := val.(bool); ok {
+						(*le)[k].ParseJSONPayload = value
+					}
+				case "params":
+					if value, ok := val.(map[string]interface{}); ok {
+						(*le)[k].Params = make(map[string]*ExtensionParam,
+							len(value))
+						for pk, pv := range value {
+							if pMap, ok := pv.(map[string]interface{}); ok {
+								(*le)[k].Params[pk] = &ExtensionParam{Name: pk}
+								for pKey, pVal := range pMap {
+									switch pKey {
+									case "type":
+										if pV, ok := pVal.(string); ok {
+											(*le)[k].Params[pk].Type = pV
+										}
+									case "optional":
+										if pV, ok := pVal.(bool); ok {
+											(*le)[k].Params[pk].Optional = pV
+										}
+									case "default":
+										(*le)[k].Params[pk].Default = pVal
+									case "description":
+										if pV, ok := pVal.(string); ok {
+											(*le)[k].Params[pk].Description = pV
+										}
+									case "alias_list":
+										if pV, ok := pVal.([]interface{}); ok {
+											(*le)[k].Params[pk].AliasList =
+												make([]string, len(pV))
+											for n, iV := range pV {
+												if itV, ok := iV.(string); ok {
+													(*le)[k].Params[pk].
+														AliasList[n] = itV
+												}
+											}
+										}
+									case "name":
+										if pV, ok := pVal.(string); ok {
+											(*le)[k].Params[pk].Name = pV
+										}
+									}
+								}
+							}
+						}
+					}
+				case "man":
+					if value, ok := val.(string); ok {
+						(*le)[k].Man = value
+					}
+				case "name":
+					if value, ok := val.(string); ok {
+						(*le)[k].Name = value
+					}
+				case "description":
+					if value, ok := val.(string); ok {
+						(*le)[k].Description = value
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetLuaExtensions retrieves information about available Lua extensions.
+func (sc *SnowthClient) GetLuaExtensions(node *SnowthNode) (LuaExtensions,
+	error) {
+	return sc.GetLuaExtensionsContext(context.Background(), node)
+}
+
+// GetLuaExtensionsContext is the context aware version of GetLuaExtensions.
+func (sc *SnowthClient) GetLuaExtensionsContext(ctx context.Context,
+	node *SnowthNode) (LuaExtensions, error) {
+	u := sc.getURL(node, "/extension/lua")
+	r := LuaExtensions{}
+	body, _, err := sc.do(ctx, node, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, err
+}
+
+// ExtParam values contain parameter values to use when executing extensions.
+type ExtParam struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ExecLuaExtension executes the specified Lua extension and returns the
+// response as a JSON map.
+func (sc *SnowthClient) ExecLuaExtension(node *SnowthNode, name string,
+	params ...*ExtParam) (map[string]interface{}, error) {
+	return sc.ExecLuaExtensionContext(context.Background(), node, name,
+		params...)
+}
+
+// ExecLuaExtensionContext is the context aware version of ExecLuaExtension.
+func (sc *SnowthClient) ExecLuaExtensionContext(ctx context.Context,
+	node *SnowthNode, name string,
+	params ...*ExtParam) (map[string]interface{}, error) {
+	u := sc.getURL(node, "/extension/lua/"+name)
+	if len(params) > 0 {
+		qp := url.Values{}
+		for _, p := range params {
+			if p != nil {
+				qp.Add(p.Name, p.Value)
+			}
+		}
+
+		u += "?" + qp.Encode()
+	}
+
+	r := map[string]interface{}{}
+	body, _, err := sc.do(ctx, node, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, err
+}

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,0 +1,189 @@
+package gosnowth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const testLuaExtensionData = `{
+	"test": {
+		"documentation": "# test\nReturns parsed payload ",
+		"method": null,
+		"PARSE_JSON_PAYLOAD": true,
+		"params": {
+			"tests": {
+				"type": "list",
+				"default": [],
+				"optional": true,
+				"alias_list": [
+					"alias"
+				],
+				"description": "comma separated list of tests to run",
+				"name": "tests"
+			},
+			"bc": {
+				"type": "boolean",
+				"default": false,
+				"optional": true,
+				"description": "print bytecode of tests"
+			},
+			"print_output": {
+				"type": "boolean",
+				"default": false,
+				"optional": true,
+				"description": "print output of test function"
+			},
+			"iterations": {
+				"type": "number",
+				"default": 1,
+				"optional": true,
+				"description": "Repeat each test multiple times"
+			}
+		},
+		"man": "",
+		"name": "test",
+		"description": "Returns parsed payload (for testing)."
+	},
+	"cor": [],
+	"registration": {
+		"documentation": "",
+		"method": null,
+		"params": [],
+		"name": "registration",
+		"description": "Returns the extension register."
+	}
+}`
+
+func TestGetLuaExtension(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI, "/extension/lua") {
+			w.Write([]byte(testLuaExtensionData))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.GetLuaExtensions(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(res))
+	}
+
+	if res["test"].Name != "test" {
+		t.Errorf("Expected name: test, got: %v", res["test"].Name)
+	}
+
+	exp := "Returns parsed payload (for testing)."
+	if res["test"].Description != exp {
+		t.Errorf("Expected name: %v, got: %v", exp, res["test"].Description)
+	}
+
+	if len(res["test"].Params) != 4 {
+		t.Fatalf("Expected params length: 4, got: %v", len(res["test"].Params))
+	}
+
+	if len(res["test"].Params["tests"].AliasList) != 1 {
+		t.Fatalf("Expected alias list length: 1, got: %v",
+			len(res["test"].Params["tests"].AliasList))
+	}
+
+	if res["test"].Params["tests"].AliasList[0] != "alias" {
+		t.Fatalf("Expected alias: alias, got: %v",
+			res["test"].Params["tests"].AliasList[0])
+	}
+
+	if v, ok := res["test"].Params["iterations"].Default.(float64); !ok ||
+		v != 1.0 {
+		t.Fatalf("Expected default: 1, got: %v", v)
+	}
+
+	if len(res["registration"].Params) != 0 {
+		t.Errorf("Expected params length: 0, got: %v",
+			len(res["registration"].Params))
+	}
+
+	if res["cor"].Description != "" {
+		t.Errorf("Expected empty description, got: %v", res["cor"].Description)
+	}
+}
+
+func TestExecLuaExtensionContext(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		if strings.HasPrefix(r.RequestURI, "/extension/lua/test") {
+			if r.URL.Query().Get("test") == "1" {
+				w.Write([]byte(`{"test":1}`))
+				return
+			}
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.ExecLuaExtension(node, "test",
+		&ExtParam{Name: "test", Value: "1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 1 {
+		t.Fatalf("Expected length: 1, got: %v", len(res))
+	}
+
+	v, ok := res["test"].(float64)
+	if !ok {
+		t.Fatal("Unexpected result test value")
+	}
+
+	if v != 1.0 {
+		t.Errorf("Expected value: 1, got: %v", v)
+	}
+}

--- a/rollup.go
+++ b/rollup.go
@@ -173,8 +173,8 @@ func (rv *RollupAllValue) Timestamp() string {
 }
 
 // ReadRollupValues reads rollup data from a node.
-func (sc *SnowthClient) ReadRollupValues(
-	node *SnowthNode, uuid, metric string, period time.Duration,
+func (sc *SnowthClient) ReadRollupValues(node *SnowthNode,
+	uuid, metric string, period time.Duration,
 	start, end time.Time, dataType string) ([]RollupValue, error) {
 	return sc.ReadRollupValuesContext(context.Background(), node, uuid, metric,
 		period, start, end, dataType)

--- a/rollup.go
+++ b/rollup.go
@@ -22,13 +22,13 @@ type RollupValue struct {
 // MarshalJSON encodes a RollupValue value into a JSON format byte slice.
 func (rv *RollupValue) MarshalJSON() ([]byte, error) {
 	v := []interface{}{}
-	tn := float64(0)
 	fv, err := strconv.ParseFloat(formatTimestamp(rv.Time), 64)
-	if err == nil {
-		tn = float64(fv)
+	if err != nil {
+		return nil, errors.New("invalid rollup value time: " +
+			formatTimestamp(rv.Time))
 	}
 
-	v = append(v, tn)
+	v = append(v, fv)
 	v = append(v, rv.Value)
 	return json.Marshal(v)
 }
@@ -36,9 +36,13 @@ func (rv *RollupValue) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes a JSON format byte slice into a RollupValue value.
 func (rv *RollupValue) UnmarshalJSON(b []byte) error {
 	v := []interface{}{}
-	json.Unmarshal(b, &v)
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
 	if len(v) != 2 {
-		return fmt.Errorf("rollup value should contain two entries: %s",
+		return errors.New("rollup value should contain two entries: " +
 			string(b))
 	}
 
@@ -83,13 +87,13 @@ type RollupAllValue struct {
 // MarshalJSON encodes a RollupValue value into a JSON format byte slice.
 func (rv *RollupAllValue) MarshalJSON() ([]byte, error) {
 	v := []interface{}{}
-	tn := float64(0)
 	fv, err := strconv.ParseFloat(formatTimestamp(rv.Time), 64)
-	if err == nil {
-		tn = float64(fv)
+	if err != nil {
+		return nil, errors.New("invalid rollup value time: " +
+			formatTimestamp(rv.Time))
 	}
 
-	v = append(v, tn)
+	v = append(v, fv)
 	v = append(v, map[string]interface{}{
 		"count":              rv.Count,
 		"value":              rv.Value,
@@ -110,9 +114,13 @@ func (rv *RollupAllValue) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes a JSON format byte slice into a RollupValue value.
 func (rv *RollupAllValue) UnmarshalJSON(b []byte) error {
 	v := []interface{}{}
-	json.Unmarshal(b, &v)
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
 	if len(v) != 2 {
-		return fmt.Errorf("rollup value should contain two entries: %s",
+		return errors.New("rollup value should contain two entries: " +
 			string(b))
 	}
 

--- a/rollup.go
+++ b/rollup.go
@@ -6,34 +6,169 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 )
 
-// RollupValues values are individual components of a roll up.
-type RollupValues struct {
-	Timestamp int64
-	Value     float64
+// RollupValue values are individual data points of a rollup.
+type RollupValue struct {
+	Time  time.Time
+	Value float64
 }
 
-// UnmarshalJSON decodes a JSON format byte slice into a RollupValues value.
-func (rv *RollupValues) UnmarshalJSON(b []byte) error {
-	tt := []interface{}{&rv.Timestamp, &rv.Value}
-	json.Unmarshal(b, &tt)
-	if len(tt) < 2 { // error not enough fields
-		return fmt.Errorf("rollup value should contain two entries,"+
-			" %d given in payload", len(tt))
+// MarshalJSON encodes a RollupValue value into a JSON format byte slice.
+func (rv *RollupValue) MarshalJSON() ([]byte, error) {
+	v := []interface{}{}
+	tn := float64(0)
+	fv, err := strconv.ParseFloat(formatTimestamp(rv.Time), 64)
+	if err == nil {
+		tn = float64(fv)
+	}
+
+	v = append(v, tn)
+	v = append(v, rv.Value)
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a RollupValue value.
+func (rv *RollupValue) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	json.Unmarshal(b, &v)
+	if len(v) != 2 {
+		return fmt.Errorf("rollup value should contain two entries: %s",
+			string(b))
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		tv, err := parseTimestamp(strconv.FormatFloat(fv, 'f', 3, 64))
+		if err != nil {
+			return err
+		}
+
+		rv.Time = tv
+	}
+
+	if fv, ok := v[1].(float64); ok {
+		rv.Value = fv
 	}
 
 	return nil
 }
 
+// Timestamp returns the RollupValue time as a string in the IRONdb timestamp
+// format.
+func (rv *RollupValue) Timestamp() string {
+	return formatTimestamp(rv.Time)
+}
+
+// RollupAllValue values contain all parts of an individual rollup data point.
+type RollupAllValue struct {
+	Time              time.Time
+	Count             int64
+	Counter           float64
+	Counter2          float64
+	CounterStddev     float64
+	Counter2Stddev    float64
+	Derivative        float64
+	Derivative2       float64
+	DerivativeStddev  float64
+	Derivative2Stddev float64
+	Stddev            float64
+	Value             float64
+}
+
+// MarshalJSON encodes a RollupValue value into a JSON format byte slice.
+func (rv *RollupAllValue) MarshalJSON() ([]byte, error) {
+	v := []interface{}{}
+	tn := float64(0)
+	fv, err := strconv.ParseFloat(formatTimestamp(rv.Time), 64)
+	if err == nil {
+		tn = float64(fv)
+	}
+
+	v = append(v, tn)
+	v = append(v, map[string]interface{}{
+		"count":              rv.Count,
+		"value":              rv.Value,
+		"stddev":             rv.Stddev,
+		"derivative":         rv.Derivative,
+		"derivative_stddev":  rv.DerivativeStddev,
+		"counter":            rv.Counter,
+		"counter_stddev":     rv.CounterStddev,
+		"derivative2":        rv.Derivative2,
+		"derivative2_stddev": rv.Derivative2Stddev,
+		"counter2":           rv.Counter2,
+		"counter2_stddev":    rv.Counter2Stddev,
+	})
+
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a RollupValue value.
+func (rv *RollupAllValue) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	json.Unmarshal(b, &v)
+	if len(v) != 2 {
+		return fmt.Errorf("rollup value should contain two entries: %s",
+			string(b))
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		tv, err := parseTimestamp(strconv.FormatFloat(fv, 'f', 3, 64))
+		if err != nil {
+			return err
+		}
+
+		rv.Time = tv
+	}
+
+	if m, ok := v[1].(map[string]interface{}); ok {
+		for key, val := range m {
+			if fv := val.(float64); ok {
+				switch key {
+				case "count":
+					rv.Count = int64(fv)
+				case "value":
+					rv.Value = fv
+				case "stddev":
+					rv.Stddev = fv
+				case "derivative":
+					rv.Derivative = fv
+				case "derivative_stddev":
+					rv.DerivativeStddev = fv
+				case "counter":
+					rv.Counter = fv
+				case "counter_stddev":
+					rv.CounterStddev = fv
+				case "derivative2":
+					rv.Derivative2 = fv
+				case "derivative2_stddev":
+					rv.Derivative2Stddev = fv
+				case "counter2":
+					rv.Counter2 = fv
+				case "counter2_stddev":
+					rv.Counter2Stddev = fv
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Timestamp returns the RollupAllValue time as a string in the IRONdb
+// timestamp format.
+func (rv *RollupAllValue) Timestamp() string {
+	return formatTimestamp(rv.Time)
+}
+
 // ReadRollupValues reads rollup data from a node.
 func (sc *SnowthClient) ReadRollupValues(
 	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
-	start, end time.Time) ([]RollupValues, error) {
+	start, end time.Time) ([]RollupValue, error) {
 	return sc.ReadRollupValuesContext(context.Background(), node, id, metric,
 		tags, rollup, start, end)
 }
@@ -41,7 +176,7 @@ func (sc *SnowthClient) ReadRollupValues(
 // ReadRollupValuesContext is the context aware version of ReadRollupValues.
 func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
 	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
-	start, end time.Time) ([]RollupValues, error) {
+	start, end time.Time) ([]RollupValue, error) {
 	startTS := start.Unix() - start.Unix()%int64(rollup/time.Second)
 	endTS := end.Unix() - end.Unix()%int64(rollup/time.Second) +
 		int64(rollup/time.Second)
@@ -53,9 +188,49 @@ func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
 		metricBuilder.WriteString("]")
 	}
 
-	r := []RollupValues{}
+	r := []RollupValue{}
 	body, _, err := sc.do(ctx, node, "GET",
-		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds",
+		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds&type=average",
+			path.Join("/rollup", id,
+				url.QueryEscape(metricBuilder.String())),
+			startTS, endTS, int(rollup/time.Second)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeJSON(body, &r); err != nil {
+		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	}
+
+	return r, nil
+}
+
+// ReadRollupAllValues reads rollup data from a node.
+func (sc *SnowthClient) ReadRollupAllValues(
+	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
+	start, end time.Time) ([]RollupAllValue, error) {
+	return sc.ReadRollupAllValuesContext(context.Background(), node, id, metric,
+		tags, rollup, start, end)
+}
+
+// ReadRollupAllValuesContext is the context aware version of ReadRollupValues.
+func (sc *SnowthClient) ReadRollupAllValuesContext(ctx context.Context,
+	node *SnowthNode, id, metric string, tags []string, rollup time.Duration,
+	start, end time.Time) ([]RollupAllValue, error) {
+	startTS := start.Unix() - start.Unix()%int64(rollup/time.Second)
+	endTS := end.Unix() - end.Unix()%int64(rollup/time.Second) +
+		int64(rollup/time.Second)
+	var metricBuilder strings.Builder
+	metricBuilder.WriteString(metric)
+	if len(tags) > 0 {
+		metricBuilder.WriteString("|ST[")
+		metricBuilder.WriteString(strings.Join(tags, ","))
+		metricBuilder.WriteString("]")
+	}
+
+	r := []RollupAllValue{}
+	body, _, err := sc.do(ctx, node, "GET",
+		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds&type=all",
 			path.Join("/rollup", id,
 				url.QueryEscape(metricBuilder.String())),
 			startTS, endTS, int(rollup/time.Second)), nil)

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -1,6 +1,8 @@
 package gosnowth
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,55 +14,121 @@ import (
 const rollupTestData = "[[1,1]]"
 
 const rollupAllTestData = `[
-    [
-        1529509020,
-        {
-            "count": 1,
-            "value": 0,
-            "stddev": 0,
-            "derivative": 0,
-            "derivative_stddev": 0,
-            "counter": 0,
-            "counter_stddev": 0,
-            "derivative2": 0,
-            "derivative2_stddev": 0,
-            "counter2": 0,
-            "counter2_stddev": 0
-        }
-    ],
-    [
-        1529509080,
-        {
-            "count": 1,
-            "value": 0,
-            "stddev": 0,
-            "derivative": 0,
-            "derivative_stddev": 0,
-            "counter": 0,
-            "counter_stddev": 0,
-            "derivative2": 0,
-            "derivative2_stddev": 0,
-            "counter2": 0,
-            "counter2_stddev": 0
-        }
-    ],
-    [
-        1529509140,
-        {
-            "count": 1,
-            "value": 0,
-            "stddev": 0,
-            "derivative": 0,
-            "derivative_stddev": 0,
-            "counter": 0,
-            "counter_stddev": 0,
-            "derivative2": 0,
-            "derivative2_stddev": 0,
-            "counter2": 0,
-            "counter2_stddev": 0
-        }
-    ]
+	[
+		1529509020,
+		{
+			"count": 1,
+			"counter": 0,
+			"counter2": 0,
+			"counter2_stddev": 0,
+			"counter_stddev": 0,
+			"derivative": 0,
+			"derivative2": 0,
+			"derivative2_stddev": 0,
+			"derivative_stddev": 0,
+			"stddev": 0,
+			"value": 0
+		}
+	],
+	[
+		1529509080,
+		{
+			"count": 1,
+			"counter": 0,
+			"counter2": 0,
+			"counter2_stddev": 0,
+			"counter_stddev": 0,
+			"derivative": 0,
+			"derivative2": 0,
+			"derivative2_stddev": 0,
+			"derivative_stddev": 0,
+			"stddev": 0,
+			"value": 0
+		}
+	],
+	[
+		1529509140,
+		{
+			"count": 1,
+			"counter": 0,
+			"counter2": 0,
+			"counter2_stddev": 0,
+			"counter_stddev": 0,
+			"derivative": 0,
+			"derivative2": 0,
+			"derivative2_stddev": 0,
+			"derivative_stddev": 0,
+			"stddev": 0,
+			"value": 0
+		}
+	]
 ]`
+
+func TestRollupValueMarshaling(t *testing.T) {
+	v := []RollupValue{}
+	err := json.NewDecoder(bytes.NewBufferString(rollupTestData)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v) != 1 {
+		t.Fatalf("Expected length: 1, got %v", len(v))
+	}
+
+	if v[0].Timestamp() != "1" {
+		t.Errorf("Expected timestamp: 1, got: %v", v[0].Timestamp())
+	}
+
+	if v[0].Value != 1.0 {
+		t.Errorf("Expected value: 1, got: %v", v[0].Value)
+	}
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.String() != rollupTestData+"\n" {
+		t.Errorf("Expected JSON: %v, got: %v", rollupTestData, buf.String())
+	}
+}
+
+func TestRollupAllValueMarshaling(t *testing.T) {
+	v := []RollupAllValue{}
+	err := json.NewDecoder(bytes.NewBufferString(rollupAllTestData)).Decode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v) != 3 {
+		t.Fatalf("Expected length: 3, got %v", len(v))
+	}
+
+	if v[0].Timestamp() != "1529509020" {
+		t.Errorf("Expected timestamp: 1, got: %v", v[0].Timestamp())
+	}
+
+	if v[0].Value != 0.0 {
+		t.Errorf("Expected value: 0, got: %v", v[0].Value)
+	}
+
+	if v[0].Count != 1 {
+		t.Errorf("Expected value: 1, got: %v", v[0].Count)
+	}
+
+	buf := &bytes.Buffer{}
+	err = json.NewEncoder(buf).Encode(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := strings.Replace(strings.Replace(strings.Replace(rollupAllTestData,
+		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	if buf.String() != exp {
+		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
+	}
+}
 
 func TestReadRollupValues(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
@@ -77,7 +145,7 @@ func TestReadRollupValues(t *testing.T) {
 
 		u := "/rollup/fc85e0ab-f568-45e6-86ee-d7443be8277d/" +
 			"online%7CST%5Btest%3Atest%5D?start_ts=1529509020" +
-			"&end_ts=1529509201&rollup_span=1s"
+			"&end_ts=1529509201&rollup_span=1s&type=average"
 		if strings.HasPrefix(r.RequestURI, u) {
 			w.Write([]byte(rollupTestData))
 			return
@@ -104,10 +172,64 @@ func TestReadRollupValues(t *testing.T) {
 	}
 
 	if len(res) != 1 {
-		t.Fatalf("Expected results: 1, got: %v", len(res))
+		t.Fatalf("Expected length: 1, got: %v", len(res))
 	}
 
 	if res[0].Value != 1 {
 		t.Errorf("Expected value: 1, got: %v", res[0].Value)
+	}
+}
+
+func TestReadRollupAllValues(t *testing.T) {
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+		if r.RequestURI == "/state" {
+			w.Write([]byte(stateTestData))
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			w.Write([]byte(statsTestData))
+			return
+		}
+
+		u := "/rollup/fc85e0ab-f568-45e6-86ee-d7443be8277d/" +
+			"online%7CST%5Btest%3Atest%5D?start_ts=1529509020" +
+			"&end_ts=1529509201&rollup_span=1s&type=all"
+		if strings.HasPrefix(r.RequestURI, u) {
+			w.Write([]byte(rollupAllTestData))
+			return
+		}
+	}))
+
+	defer ms.Close()
+	sc, err := NewSnowthClient(false, ms.URL)
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+	res, err := sc.ReadRollupAllValues(node,
+		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", []string{"test:test"},
+		time.Second, time.Unix(1529509020, 0), time.Unix(1529509200, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(res))
+	}
+
+	if res[0].Count != 1 {
+		t.Errorf("Expected count: 1, got: %v", res[0].Count)
+	}
+
+	if res[0].Value != 0 {
+		t.Errorf("Expected value: 0, got: %v", res[0].Value)
 	}
 }

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -144,8 +144,8 @@ func TestReadRollupValues(t *testing.T) {
 		}
 
 		u := "/rollup/fc85e0ab-f568-45e6-86ee-d7443be8277d/" +
-			"online%7CST%5Btest%3Atest%5D?start_ts=1529509020" +
-			"&end_ts=1529509201&rollup_span=1s&type=average"
+			"online?start_ts=1529509020&end_ts=1529509201&rollup_span=1s" +
+			"&type=average"
 		if strings.HasPrefix(r.RequestURI, u) {
 			w.Write([]byte(rollupTestData))
 			return
@@ -165,8 +165,8 @@ func TestReadRollupValues(t *testing.T) {
 
 	node := &SnowthNode{url: u}
 	res, err := sc.ReadRollupValues(node,
-		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", []string{"test:test"},
-		time.Second, time.Unix(1529509020, 0), time.Unix(1529509200, 0))
+		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", time.Second,
+		time.Unix(1529509020, 0), time.Unix(1529509200, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,8 +194,8 @@ func TestReadRollupAllValues(t *testing.T) {
 		}
 
 		u := "/rollup/fc85e0ab-f568-45e6-86ee-d7443be8277d/" +
-			"online%7CST%5Btest%3Atest%5D?start_ts=1529509020" +
-			"&end_ts=1529509201&rollup_span=1s&type=all"
+			"online?start_ts=1529509020&end_ts=1529509201&rollup_span=1s" +
+			"&type=all"
 		if strings.HasPrefix(r.RequestURI, u) {
 			w.Write([]byte(rollupAllTestData))
 			return
@@ -215,8 +215,8 @@ func TestReadRollupAllValues(t *testing.T) {
 
 	node := &SnowthNode{url: u}
 	res, err := sc.ReadRollupAllValues(node,
-		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", []string{"test:test"},
-		time.Second, time.Unix(1529509020, 0), time.Unix(1529509200, 0))
+		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", time.Second,
+		time.Unix(1529509020, 0), time.Unix(1529509200, 0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -166,7 +166,7 @@ func TestReadRollupValues(t *testing.T) {
 	node := &SnowthNode{url: u}
 	res, err := sc.ReadRollupValues(node,
 		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "online", time.Second,
-		time.Unix(1529509020, 0), time.Unix(1529509200, 0))
+		time.Unix(1529509020, 0), time.Unix(1529509200, 0), "average")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/text.go
+++ b/text.go
@@ -42,20 +42,20 @@ type TextValue struct {
 }
 
 // ReadTextValues reads text data values from an IRONdb node.
-func (sc *SnowthClient) ReadTextValues(node *SnowthNode, start, end time.Time,
-	id, metric string) ([]TextValue, error) {
-	return sc.ReadTextValuesContext(context.Background(), node, start, end,
-		id, metric)
+func (sc *SnowthClient) ReadTextValues(node *SnowthNode, uuid, metric string,
+	start, end time.Time) ([]TextValue, error) {
+	return sc.ReadTextValuesContext(context.Background(), node, uuid, metric,
+		start, end)
 }
 
 // ReadTextValuesContext is the context aware version of ReadTextValues.
 func (sc *SnowthClient) ReadTextValuesContext(ctx context.Context,
-	node *SnowthNode, start, end time.Time,
-	id, metric string) ([]TextValue, error) {
+	node *SnowthNode, uuid, metric string,
+	start, end time.Time) ([]TextValue, error) {
 	r := TextValueResponse{}
 	body, _, err := sc.do(ctx, node, "GET", path.Join("/read",
 		strconv.FormatInt(start.Unix(), 10),
-		strconv.FormatInt(end.Unix(), 10), id, metric), nil)
+		strconv.FormatInt(end.Unix(), 10), uuid, metric), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/text_test.go
+++ b/text_test.go
@@ -15,7 +15,7 @@ const textTestData = `[[1380000000,"hello"],[1380000300,"world"]]`
 func TestTextValue(t *testing.T) {
 	tvr := TextValueResponse{}
 	if err := json.Unmarshal([]byte(textTestData), &tvr); err != nil {
-		t.Error("error unmarshalling: ", err)
+		t.Error("error unmarshaling: ", err)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestReadTextValues(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.ReadTextValues(node, time.Unix(1, 0), time.Unix(2, 0),
-		"3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d", "test")
+	res, err := sc.ReadTextValues(node, "3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d",
+		"test", time.Unix(1, 0), time.Unix(2, 0))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Adds methods for listing Lua extensions and calling any Lua extension via the IRONdb extension APIs.
- Adds specific support for CAQL queries via a separate method.
- Adds support for a Go data structure representation of the DF4 data format.
- Updates unit tests to cover all new methods and types.
- Adds support for reading histogram data, and adds types to represent histogram data responses.
- Improves handling of rollup data responses and adds support for legacy / type=all rollup data responses.
- Adds support for making data requests using the /fetch API.
- Allows rollup values to be read for any type, not only 'average' values.