### PR TITLE
CIRC-3360: Improve CAQL queries and errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -163,6 +163,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.4.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.4.2
 [v1.4.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.4.1
 [v1.4.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.4.0
 [v1.3.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.3.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,20 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.4.2] - 2019-09-20
+
+### Changed
+
+- Changed the signature for the SnowthClient.GetCAQLQuery() methods to use the
+new CAQLQuery type as a parameter. This allows all available parameters to be
+used when executing CAQL queries.
+- Added the CAQLError type which may be returned by the
+SnowthClient.GetCAQLQuery() methods as an error if the error returned from the
+corresponding IRONdb API call can be represented from this type. This allows
+retrieval of extended error information when CAQL query requests fail.
+- The SnowthClient.GetCAQLQuery() methods now send CAQL query requests to IRONdb
+via a POST request. This prevents potential problems with query string encoding.
+
 ## [v1.4.1] - 2019-09-19
 
 ### Fixed

--- a/caql.go
+++ b/caql.go
@@ -1,53 +1,95 @@
 package gosnowth
 
 import (
+	"bytes"
 	"context"
-	"fmt"
-	"net/url"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 )
 
 // CAQLQuery values represent CAQL queries and associated parameters.
 type CAQLQuery struct {
-	Query   string
-	Start   int64
-	End     int64
-	Period  int64
-	Timeout int64
+	Format               string   `json:"format"`
+	Query                string   `json:"q"`
+	Period               int64    `json:"period"`
+	ID                   int64    `json:"_id"`
+	IgnoreDurationLimits bool     `json:"ignore_duration_limits"`
+	PrepareResults       string   `json:"prepare_results"`
+	AccountID            int64    `json:"account_id,string"`
+	Method               string   `json:"method"`
+	Start                int64    `json:"start_time"`
+	Timeout              int64    `json:"_timeout"`
+	MinPrefill           int64    `json:"min_prefill"`
+	Debug                byte     `json:"_debug"`
+	Expansion            []string `json:"expansion"`
+	End                  int64    `json:"end_time,omitempty"`
+}
+
+// CAQLUserError values contain messages describing a CAQL error for a user.
+type CAQLUserError struct {
+	Message string `json:"message,omitempty"`
+}
+
+// CAQLError values contain information about an error returned by the CAQL
+//extension.
+type CAQLError struct {
+	Locals    []string      `json:"locals"`
+	Method    string        `json:"method"`
+	Trace     []string      `json:"trace"`
+	UserError CAQLUserError `json:"user_error"`
+	Status    string        `json:"status"`
+	Arguments CAQLQuery     `json:"arguments"`
+	Success   bool          `json:"success"`
+}
+
+// String returns this value as a JSON format string.
+func (ce *CAQLError) String() string {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(ce); err != nil {
+		return "unable to encode JSON: " + err.Error()
+	}
+
+	return buf.String()
+}
+
+// String returns this error as a JSON format string.
+func (ce *CAQLError) Error() string {
+	return ce.String()
 }
 
 // GetCAQLQuery retrieves data values for metrics matching a CAQL format.
-func (sc *SnowthClient) GetCAQLQuery(node *SnowthNode, accountID int64,
+func (sc *SnowthClient) GetCAQLQuery(node *SnowthNode,
 	q *CAQLQuery) (*DF4Response, error) {
-	return sc.GetCAQLQueryContext(context.Background(), node, accountID, q)
+	return sc.GetCAQLQueryContext(context.Background(), node, q)
 }
 
 // GetCAQLQueryContext is the context aware version of GetCAQLQuery.
 func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context,
-	node *SnowthNode, accountID int64, q *CAQLQuery) (*DF4Response, error) {
-	u := sc.getURL(node, "/extension/lua/public/caql_v1") +
-		"?query=" + url.PathEscape(q.Query)
-	if q.Start != 0 {
-		u += fmt.Sprintf("&start=%d", q.Start)
+	node *SnowthNode, q *CAQLQuery) (*DF4Response, error) {
+	if q == nil {
+		q = &CAQLQuery{}
 	}
 
-	if q.End != 0 {
-		u += fmt.Sprintf("&end=%d", q.End)
-	}
-
-	if q.Period != 0 {
-		u += fmt.Sprintf("&period=%d", q.Period)
-	}
-
-	if q.Timeout != 0 {
-		u += fmt.Sprintf("&_timeout=%d", q.Timeout)
-	}
-
-	u += fmt.Sprintf("&format=DF4&account_id=%d", accountID)
-	r := &DF4Response{}
-	body, _, err := sc.do(ctx, node, "GET", u, nil)
+	u := sc.getURL(node, "/extension/lua/public/caql_v1")
+	q.Format = "DF4"
+	qBuf, err := encodeJSON(q)
 	if err != nil {
+		return nil, err
+	}
+
+	r := &DF4Response{}
+	body, _, err := sc.do(ctx, node, "POST", u, qBuf)
+	if err != nil {
+		if body != nil {
+			cErr := &CAQLError{}
+			if err := decodeJSON(body, &cErr); err == nil {
+				return nil, cErr
+			}
+		}
+
 		return nil, err
 	}
 

--- a/caql.go
+++ b/caql.go
@@ -10,6 +10,24 @@ import (
 
 // CAQLQuery values represent CAQL queries and associated parameters.
 type CAQLQuery struct {
+	Format               string   `json:"format,omitempty"`
+	Query                string   `json:"q,omitempty"`
+	Period               int64    `json:"period,omitempty"`
+	ID                   int64    `json:"_id,omitempty"`
+	IgnoreDurationLimits bool     `json:"ignore_duration_limits,omitempty"`
+	PrepareResults       string   `json:"prepare_results,omitempty"`
+	AccountID            int64    `json:"account_id,string,omitempty"`
+	Method               string   `json:"method,omitempty"`
+	Start                int64    `json:"start_time,omitempty"`
+	Timeout              int64    `json:"_timeout,omitempty"`
+	MinPrefill           int64    `json:"min_prefill,omitempty"`
+	Debug                byte     `json:"_debug,omitempty"`
+	Expansion            []string `json:"expansion,omitempty"`
+	End                  int64    `json:"end_time,omitempty"`
+}
+
+// CAQLErrorArgs values represent CAQL request arguments returned in an error.
+type CAQLErrorArgs struct {
 	Format               string   `json:"format"`
 	Query                string   `json:"q"`
 	Period               int64    `json:"period"`
@@ -23,7 +41,7 @@ type CAQLQuery struct {
 	MinPrefill           int64    `json:"min_prefill"`
 	Debug                byte     `json:"_debug"`
 	Expansion            []string `json:"expansion"`
-	End                  int64    `json:"end_time,omitempty"`
+	End                  int64    `json:"end_time"`
 }
 
 // CAQLUserError values contain messages describing a CAQL error for a user.
@@ -39,7 +57,7 @@ type CAQLError struct {
 	Trace     []string      `json:"trace"`
 	UserError CAQLUserError `json:"user_error"`
 	Status    string        `json:"status"`
-	Arguments CAQLQuery     `json:"arguments"`
+	Arguments CAQLErrorArgs `json:"arguments"`
 	Success   bool          `json:"success"`
 }
 

--- a/caql_test.go
+++ b/caql_test.go
@@ -1,12 +1,52 @@
 package gosnowth
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
+
+const testCAQLError = `{
+	"locals": [],
+	"method": "caql_v1",
+	"trace": [
+		"[C]:-1:error",
+		"/opt/circonus/lib/amd64/snowth/support/caql_builder.lua:133:lookup_function",
+		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:32:node_2_pu",
+		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:46:node_recurse",
+		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:149:compile",
+		"/opt/circonus/lib/amd64/snowth/support/caql_fetch.lua:110:<unknown>",
+		"[C]:-1:xpcall",
+		"/opt/circonus/lib/amd64/snowth/support/utils_extension.lua:273:<unknown>",
+		"[C]:-1:xpcall",
+		"/opt/circonus/lib/amd64/snowth/support/snowth-init.lua:307:extension_process",
+		".../circonus/lib/amd64/snowth/support/luamtev-extension.lua:118:<unknown>"
+	],
+	"user_error": {
+		"message": "Function not found: histograms"
+	},
+	"status": "520 (User facing error)",
+	"arguments": {
+		"format": "DF4",
+		"q": "find:histograms(\"latency\",\"and(service:api)\")",
+		"period": 300,
+		"_id": 33545929,
+		"ignore_duration_limits": false,
+		"prepare_results": "JSON",
+		"account_id": "1",
+		"method": "fetch",
+		"start_time": 1567500000,
+		"_timeout": 15,
+		"min_prefill": 0,
+		"_debug": 0,
+		"expansion": [],
+		"end_time": 1567566000
+	},
+	"success": false
+}`
 
 func TestGetCAQLQuery(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
@@ -21,8 +61,21 @@ func TestGetCAQLQuery(t *testing.T) {
 			return
 		}
 
-		if strings.HasPrefix(r.RequestURI,
-			"/extension/lua/public/caql_v1?query=test") {
+		if r.Method == "POST" && strings.HasPrefix(r.RequestURI,
+			"/extension/lua/public/caql_v1") {
+			b, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(testCAQLError))
+				return
+			}
+
+			if strings.Contains(string(b), "histograms") {
+				w.WriteHeader(502)
+				w.Write([]byte(testCAQLError))
+				return
+			}
+
 			w.Write([]byte(testDF4Response))
 			return
 		}
@@ -40,11 +93,12 @@ func TestGetCAQLQuery(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.GetCAQLQuery(node, 1, &CAQLQuery{
-		Query:  "test",
-		Start:  0,
-		End:    900,
-		Period: 300,
+	res, err := sc.GetCAQLQuery(node, &CAQLQuery{
+		AccountID: 1,
+		Query:     "test",
+		Start:     0,
+		End:       900,
+		Period:    300,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -73,5 +127,35 @@ func TestGetCAQLQuery(t *testing.T) {
 
 	if res.Meta[0].Label != "test" {
 		t.Errorf("Expected meta label: test, got: %v", res.Meta[0].Label)
+	}
+
+	_, err = sc.GetCAQLQuery(node, &CAQLQuery{
+		AccountID: 1,
+		Query:     "find:histograms()",
+		Start:     0,
+		End:       900,
+		Period:    300,
+	})
+	if err == nil {
+		t.Fatal("Expected CAQL error response")
+	}
+
+	vErr, ok := err.(*CAQLError)
+	if !ok {
+		t.Fatalf("Expected error type: CAQLError, got: %T", err)
+	}
+
+	exp := "Function not found: histograms"
+	if vErr.UserError.Message != exp {
+		t.Errorf("Expected user error: %v, got: %v", exp,
+			vErr.UserError.Message)
+	}
+
+	exp = strings.Replace(strings.Replace(strings.Replace(testCAQLError,
+		" ", "", -1), "\t", "", -1), "\n", "", -1)
+	val := strings.Replace(strings.Replace(strings.Replace(vErr.Error(),
+		" ", "", -1), "\t", "", -1), "\n", "", -1)
+	if val != exp {
+		t.Errorf("Expected error JSON: %v, got: %v", exp, val)
 	}
 }

--- a/caql_test.go
+++ b/caql_test.go
@@ -12,19 +12,7 @@ import (
 const testCAQLError = `{
 	"locals": [],
 	"method": "caql_v1",
-	"trace": [
-		"[C]:-1:error",
-		"/opt/circonus/lib/amd64/snowth/support/caql_builder.lua:133:lookup_function",
-		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:32:node_2_pu",
-		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:46:node_recurse",
-		".../circonus/lib/amd64/snowth/support/caql_processor_v1.lua:149:compile",
-		"/opt/circonus/lib/amd64/snowth/support/caql_fetch.lua:110:<unknown>",
-		"[C]:-1:xpcall",
-		"/opt/circonus/lib/amd64/snowth/support/utils_extension.lua:273:<unknown>",
-		"[C]:-1:xpcall",
-		"/opt/circonus/lib/amd64/snowth/support/snowth-init.lua:307:extension_process",
-		".../circonus/lib/amd64/snowth/support/luamtev-extension.lua:118:<unknown>"
-	],
+	"trace": [],
 	"user_error": {
 		"message": "Function not found: histograms"
 	},

--- a/client.go
+++ b/client.go
@@ -615,6 +615,7 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 	}
 
 	sc.LogDebugf("snowth response: %+v", resp)
+	sc.LogDebugf("snowth response body: %v", string(res))
 	sc.LogDebugf("snowth latency: %+v", time.Since(start))
 	select {
 	case <-ctx.Done():
@@ -625,8 +626,9 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 	if resp.StatusCode != http.StatusOK {
 		sc.LogWarnf("error returned from IRONdb: [%d] %s",
 			resp.StatusCode, string(res))
-		return nil, nil, fmt.Errorf("error returned from IRONdb: [%d] %s",
-			resp.StatusCode, string(res))
+		return bytes.NewBuffer(res), resp.Header,
+			fmt.Errorf("error returned from IRONdb: [%d] %s",
+				resp.StatusCode, string(res))
 	}
 
 	return bytes.NewBuffer(res), resp.Header, nil

--- a/common.go
+++ b/common.go
@@ -59,6 +59,18 @@ func (me multiError) Error() string {
 	return me.String()
 }
 
+// encodeJSON create a reader of JSON data representing an interface.
+func encodeJSON(v interface{}) (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, errors.Wrap(err, "failed to encode JSON")
+	}
+
+	return buf, nil
+}
+
 // decodeJSON decodes JSON from a reader into an interface.
 func decodeJSON(r io.Reader, v interface{}) error {
 	if err := json.NewDecoder(r).Decode(v); err != nil {


### PR DESCRIPTION
- Changed the signature for the SnowthClient.GetCAQLQuery() methods to use the
new CAQLQuery type as a parameter. This allows all available parameters to be
used when executing CAQL queries.
- Added the CAQLError type which may be returned by the
SnowthClient.GetCAQLQuery() methods as an error if the error returned from the
corresponding IRONdb API call can be represented from this type. This allows
retrieval of extended error information when CAQL query requests fail.
- The SnowthClient.GetCAQLQuery() methods now send CAQL query requests to IRONdb
via a POST request. This prevents potential problems with query string encoding.