### PR TITLE
CIRC-2444: Fix missing nil check in rollup JSON handling

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+### Fixed
+
+- Bug (severe): An issue was fixed that resulted in panics when rollup result
+data, containing null values in specific places, was decoded from JSON format.
+Created: 2019-09-16. Fixed: 2019-11-15.
+
 ## [v1.4.3] - 2019-09-20
 
 ### Changed

--- a/rollup.go
+++ b/rollup.go
@@ -146,7 +146,7 @@ func (rv *RollupAllValue) UnmarshalJSON(b []byte) error {
 	if m, ok := v[1].(map[string]interface{}); ok {
 		rv.Data = &RollupAllData{}
 		for key, val := range m {
-			if fv := val.(float64); ok {
+			if fv, ok := val.(float64); ok {
 				switch key {
 				case "count":
 					rv.Data.Count = int64(fv)


### PR DESCRIPTION
- Adds a nil check to prevent panicking when unmarshalling rollup JSON data containing null values.