### PR TITLE
CIRC-4388: Support new IRONdb find parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+### Changed
+
+- Changed the signature of the SnowthClient.FindTags() and
+SnowthClient.FindTagsContext() methods to accept a variable number of
+*FindTagsOption parameters. This allows more flexibility when passing optional
+arguments to the underlying IRONdb find calls.
+
 ## [v1.4.4] - 2019-11-21
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,16 +8,16 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ### Added
 
-- Added a new FindTagsLatest type and a new 'Latest' field to the FindTagsItem
-type to support SnowthClient.FindTags() returning the latest data values when
+- Added a new FindTagsLatest type and a new 'Latest' field to the `FindTagsItem`
+type to support `SnowthClient.FindTags()` returning the latest data values when
 requested from the IRONdb find call.
 
 ### Changed
 
-- Changed the signature of the SnowthClient.FindTags() and
-SnowthClient.FindTagsContext() methods to accept a *FindTagsOptions argument.
-This argument contains the values for the supported IRONdb find operation query
-parameters.
+- Changed the signature of the `SnowthClient.FindTags()` and
+`SnowthClient.FindTagsContext()` methods to accept a `*FindTagsOptions`
+argument. This argument contains the values for the supported IRONdb find
+operation query parameters.
 
 ## [v1.4.4] - 2019-11-21
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,9 +15,9 @@ requested from the IRONdb find call.
 ### Changed
 
 - Changed the signature of the SnowthClient.FindTags() and
-SnowthClient.FindTagsContext() methods to accept a variable number of
-*FindTagsOption parameters. This allows more flexibility when passing optional
-arguments to the underlying IRONdb find calls.
+SnowthClient.FindTagsContext() methods to accept a *FindTagsOptions argument.
+This argument contains the values for the supported IRONdb find operation query
+parameters.
 
 ## [v1.4.4] - 2019-11-21
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+### Added
+
+- Added a new FindTagsLatest type and a new 'Latest' field to the FindTagsItem
+type to support SnowthClient.FindTags() returning the latest data values when
+requested from the IRONdb find call.
+
 ### Changed
 
 - Changed the signature of the SnowthClient.FindTags() and

--- a/client_test.go
+++ b/client_test.go
@@ -85,8 +85,10 @@ func TestSnowthClientRequest(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.FindTags(node, 1, "test", FindTagsOptionStart("1"),
-		FindTagsOptionEnd("1"))
+	res, err := sc.FindTags(node, 1, "test", &FindTagsOptions{
+		Start: time.Unix(1, 0),
+		End:   time.Unix(2, 0),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,8 +172,10 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 		currentTopology: "294cbd39999c2270964029691e8bc5e231a867d525ccba62181dc8988ff218dc",
 	}
 
-	res, err := sc.FindTags(node, 1, "test", FindTagsOptionStart("1"),
-		FindTagsOptionEnd("1"))
+	res, err := sc.FindTags(node, 1, "test", &FindTagsOptions{
+		Start: time.Unix(1, 0),
+		End:   time.Unix(2, 0),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -85,7 +85,8 @@ func TestSnowthClientRequest(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.FindTags(node, 1, "test", "1", "1")
+	res, err := sc.FindTags(node, 1, "test", FindTagsOptionStart("1"),
+		FindTagsOptionEnd("1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +170,8 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 		currentTopology: "294cbd39999c2270964029691e8bc5e231a867d525ccba62181dc8988ff218dc",
 	}
 
-	res, err := sc.FindTags(node, 1, "test", "1", "1")
+	res, err := sc.FindTags(node, 1, "test", FindTagsOptionStart("1"),
+		FindTagsOptionEnd("1"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -12,6 +12,22 @@ import (
 	"time"
 )
 
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 type noOpReadCloser struct {
 	*bytes.Buffer
 	WasClosed bool

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -88,9 +88,8 @@ func ExampleReadText() {
 			log.Fatalf("failed to write text data: %v", err)
 		}
 
-		data, err := client.ReadTextValues(node,
-			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second),
-			id, "test-text-metric2")
+		data, err := client.ReadTextValues(node, id, "test-text-metric2",
+			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second))
 		if err != nil {
 			log.Fatalf("failed to read text data: %v", err)
 		}

--- a/tags.go
+++ b/tags.go
@@ -204,14 +204,8 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, node *SnowthNode,
 			formatTimestamp(options.Start), formatTimestamp(options.End))
 	}
 
-	if options.Activity != 0 {
-		u += fmt.Sprintf("&activity=%d", options.Activity)
-	}
-
-	if options.Latest != 0 {
-		u += fmt.Sprintf("&latest=%d", options.Latest)
-	}
-
+	u += fmt.Sprintf("&activity=%d", options.Activity)
+	u += fmt.Sprintf("&latest=%d", options.Latest)
 	if options.CountOnly != 0 {
 		u += fmt.Sprintf("&count_only=%d", options.CountOnly)
 	}

--- a/tags.go
+++ b/tags.go
@@ -46,7 +46,7 @@ type FindTagsLatest struct {
 // FindTagsLatestNumeric values contain recent metric numeric data.
 type FindTagsLatestNumeric struct {
 	Time  int64
-	Value float64
+	Value *float64
 }
 
 // MarshalJSON encodes a FindTagsLatestNumeric value into a JSON format byte
@@ -66,21 +66,21 @@ func (ftl *FindTagsLatestNumeric) UnmarshalJSON(b []byte) error {
 	}
 
 	if len(v) != 2 {
-		return fmt.Errorf("unable to decode latest histogram value, "+
+		return fmt.Errorf("unable to decode latest numeric value, "+
 			"invalid length: %v: %v", string(b), err)
 	}
 
 	if fv, ok := v[0].(float64); ok {
 		ftl.Time = int64(fv)
 	} else {
-		return fmt.Errorf("unable to decode latest histogram value, "+
+		return fmt.Errorf("unable to decode latest numeric value, "+
 			"invalid timestamp: %v", string(b))
 	}
 
 	if fv, ok := v[1].(float64); ok {
-		ftl.Value = fv
+		ftl.Value = &fv
 	} else {
-		return fmt.Errorf("unable to decode latest histogram value, "+
+		return fmt.Errorf("unable to decode latest numeric value, "+
 			"invalid value: %v", string(b))
 	}
 
@@ -90,7 +90,7 @@ func (ftl *FindTagsLatestNumeric) UnmarshalJSON(b []byte) error {
 // FindTagsLatestText values contain recent metric text data.
 type FindTagsLatestText struct {
 	Time  int64
-	Value string
+	Value *string
 }
 
 // MarshalJSON encodes a FindTagsLatestText value into a JSON format byte slice.
@@ -121,7 +121,7 @@ func (ftl *FindTagsLatestText) UnmarshalJSON(b []byte) error {
 	}
 
 	if sv, ok := v[1].(string); ok {
-		ftl.Value = sv
+		ftl.Value = &sv
 	} else {
 		return fmt.Errorf("unable to decode latest text value, "+
 			"invalid value: %v", string(b))
@@ -133,7 +133,7 @@ func (ftl *FindTagsLatestText) UnmarshalJSON(b []byte) error {
 // FindTagsLatestHistogram values contain recent metric histogram data.
 type FindTagsLatestHistogram struct {
 	Time  int64
-	Value string
+	Value *string
 }
 
 // MarshalJSON encodes a FindTagsLatestHistogram value into a JSON format byte
@@ -165,7 +165,7 @@ func (ftl *FindTagsLatestHistogram) UnmarshalJSON(b []byte) error {
 	}
 
 	if sv, ok := v[1].(string); ok {
-		ftl.Value = sv
+		ftl.Value = &sv
 	} else {
 		return fmt.Errorf("unable to decode latest histogram value, "+
 			"invalid value: %v", string(b))

--- a/tags.go
+++ b/tags.go
@@ -27,19 +27,93 @@ type FindTagsResult struct {
 	Count int64
 }
 
+// FindTagsOption values contain optional parameters to be passed to the
+// IRONdb find tags call by a FindTags operation.
+type FindTagsOption struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// NewFindTagsOption creates a new find tags option with any name and value.
+func NewFindTagsOption(name, value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// FindTagsOptionStart creates a new find tags option for activity start.
+func FindTagsOptionStart(value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  "activity_start_secs",
+		Value: value,
+	}
+}
+
+// FindTagsOptionEnd creates a new find tags option for activity end.
+func FindTagsOptionEnd(value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  "activity_end_secs",
+		Value: value,
+	}
+}
+
+// FindTagsOptionActivity creates a new find tags option for retrieving
+// activity window data.
+func FindTagsOptionActivity(value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  "activity",
+		Value: value,
+	}
+}
+
+// FindTagsOptionLatest creates a new find tags option for retrieving latest
+// metric values.
+func FindTagsOptionLatest(value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  "latest",
+		Value: value,
+	}
+}
+
+// FindTagsOptionCountOnly creates a new find tags option for retrieving only
+// the count of matching metrics.
+func FindTagsOptionCountOnly(value string) *FindTagsOption {
+	return &FindTagsOption{
+		Name:  "count_only",
+		Value: value,
+	}
+}
+
 // FindTags retrieves metrics that are associated with the provided tag query.
 func (sc *SnowthClient) FindTags(node *SnowthNode, accountID int64,
-	query string, start, end string) (*FindTagsResult, error) {
+	query string, opts ...*FindTagsOption) (*FindTagsResult, error) {
 	return sc.FindTagsContext(context.Background(), node, accountID, query,
-		start, end)
+		opts...)
 }
 
 // FindTagsContext is the context aware version of FindTags.
 func (sc *SnowthClient) FindTagsContext(ctx context.Context, node *SnowthNode,
-	accountID int64, query string, start, end string) (*FindTagsResult, error) {
+	accountID int64, query string,
+	opts ...*FindTagsOption) (*FindTagsResult, error) {
 	u := fmt.Sprintf("%s?query=%s",
 		sc.getURL(node, fmt.Sprintf("/find/%d/tags", accountID)),
 		url.QueryEscape(query))
+	start, end := "", ""
+	for _, opt := range opts {
+		if opt != nil {
+			switch opt.Name {
+			case "start", "activity_start_secs":
+				start = opt.Value
+			case "end", "activity_end_secs":
+				end = opt.Value
+			default:
+				u += fmt.Sprintf("&%s=%s", url.QueryEscape(opt.Name),
+					url.QueryEscape(opt.Value))
+			}
+		}
+	}
+
 	if start != "" && end != "" {
 		u += fmt.Sprintf("&activity_start_secs=%s&activity_end_secs=%s",
 			url.QueryEscape(start), url.QueryEscape(end))

--- a/tags.go
+++ b/tags.go
@@ -77,11 +77,13 @@ func (ftl *FindTagsLatestNumeric) UnmarshalJSON(b []byte) error {
 			"invalid timestamp: %v", string(b))
 	}
 
-	if fv, ok := v[1].(float64); ok {
-		ftl.Value = &fv
-	} else {
-		return fmt.Errorf("unable to decode latest numeric value, "+
-			"invalid value: %v", string(b))
+	if v[1] != nil {
+		if fv, ok := v[1].(float64); ok {
+			ftl.Value = &fv
+		} else {
+			return fmt.Errorf("unable to decode latest numeric value, "+
+				"invalid value: %v", string(b))
+		}
 	}
 
 	return nil
@@ -120,11 +122,13 @@ func (ftl *FindTagsLatestText) UnmarshalJSON(b []byte) error {
 			"invalid timestamp: %v", string(b))
 	}
 
-	if sv, ok := v[1].(string); ok {
-		ftl.Value = &sv
-	} else {
-		return fmt.Errorf("unable to decode latest text value, "+
-			"invalid value: %v", string(b))
+	if v[1] != nil {
+		if sv, ok := v[1].(string); ok {
+			ftl.Value = &sv
+		} else {
+			return fmt.Errorf("unable to decode latest text value, "+
+				"invalid value: %v", string(b))
+		}
 	}
 
 	return nil
@@ -164,11 +168,13 @@ func (ftl *FindTagsLatestHistogram) UnmarshalJSON(b []byte) error {
 			"invalid timestamp: %v", string(b))
 	}
 
-	if sv, ok := v[1].(string); ok {
-		ftl.Value = &sv
-	} else {
-		return fmt.Errorf("unable to decode latest histogram value, "+
-			"invalid value: %v", string(b))
+	if v[1] != nil {
+		if sv, ok := v[1].(string); ok {
+			ftl.Value = &sv
+		} else {
+			return fmt.Errorf("unable to decode latest histogram value, "+
+				"invalid value: %v", string(b))
+		}
 	}
 
 	return nil

--- a/tags.go
+++ b/tags.go
@@ -2,6 +2,7 @@ package gosnowth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -11,14 +12,15 @@ import (
 
 // FindTagsItem values represent results returned from IRONdb tag queries.
 type FindTagsItem struct {
-	UUID       string    `json:"uuid"`
-	CheckName  string    `json:"check_name"`
-	CheckTags  []string  `json:"check_tags,omitempty"`
-	MetricName string    `json:"metric_name"`
-	Category   string    `json:"category"`
-	Type       string    `type:"type"`
-	AccountID  int64     `json:"account_id"`
-	Activity   [][]int64 `json:"activity,omitempty"`
+	UUID       string          `json:"uuid"`
+	CheckName  string          `json:"check_name"`
+	CheckTags  []string        `json:"check_tags,omitempty"`
+	MetricName string          `json:"metric_name"`
+	Category   string          `json:"category"`
+	Type       string          `type:"type"`
+	AccountID  int64           `json:"account_id"`
+	Activity   [][]int64       `json:"activity,omitempty"`
+	Latest     *FindTagsLatest `json:"latest,omitempty"`
 }
 
 // FindTagsResult values contain the results of a find tags request.
@@ -32,6 +34,144 @@ type FindTagsResult struct {
 type FindTagsOption struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+}
+
+// FindTagsLatest values contain the most recent data values for a metric.
+type FindTagsLatest struct {
+	Numeric   []FindTagsLatestNumeric   `json:"numeric,omitempty"`
+	Text      []FindTagsLatestText      `json:"text,omitempty"`
+	Histogram []FindTagsLatestHistogram `json:"histogram,omitempty"`
+}
+
+// FindTagsLatestNumeric values contain recent metric numeric data.
+type FindTagsLatestNumeric struct {
+	Time  int64
+	Value float64
+}
+
+// MarshalJSON encodes a FindTagsLatestNumeric value into a JSON format byte
+// slice.
+func (ftl *FindTagsLatestNumeric) MarshalJSON() ([]byte, error) {
+	v := []interface{}{ftl.Time, ftl.Value}
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a FindTagsLatestNumeric
+// value.
+func (ftl *FindTagsLatestNumeric) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	if len(v) != 2 {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid length: %v: %v", string(b), err)
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		ftl.Time = int64(fv)
+	} else {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid timestamp: %v", string(b))
+	}
+
+	if fv, ok := v[1].(float64); ok {
+		ftl.Value = fv
+	} else {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid value: %v", string(b))
+	}
+
+	return nil
+}
+
+// FindTagsLatestText values contain recent metric text data.
+type FindTagsLatestText struct {
+	Time  int64
+	Value string
+}
+
+// MarshalJSON encodes a FindTagsLatestText value into a JSON format byte slice.
+func (ftl *FindTagsLatestText) MarshalJSON() ([]byte, error) {
+	v := []interface{}{ftl.Time, ftl.Value}
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a FindTagsLatestText
+// value.
+func (ftl *FindTagsLatestText) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	if len(v) != 2 {
+		return fmt.Errorf("unable to decode latest text value, "+
+			"invalid length: %v: %v", string(b), err)
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		ftl.Time = int64(fv)
+	} else {
+		return fmt.Errorf("unable to decode latest text value, "+
+			"invalid timestamp: %v", string(b))
+	}
+
+	if sv, ok := v[1].(string); ok {
+		ftl.Value = sv
+	} else {
+		return fmt.Errorf("unable to decode latest text value, "+
+			"invalid value: %v", string(b))
+	}
+
+	return nil
+}
+
+// FindTagsLatestHistogram values contain recent metric histogram data.
+type FindTagsLatestHistogram struct {
+	Time  int64
+	Value string
+}
+
+// MarshalJSON encodes a FindTagsLatestHistogram value into a JSON format byte
+// slice.
+func (ftl *FindTagsLatestHistogram) MarshalJSON() ([]byte, error) {
+	v := []interface{}{ftl.Time, ftl.Value}
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a JSON format byte slice into a
+// FindTagsLatestHistogram value.
+func (ftl *FindTagsLatestHistogram) UnmarshalJSON(b []byte) error {
+	v := []interface{}{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	if len(v) != 2 {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid length: %v: %v", string(b), err)
+	}
+
+	if fv, ok := v[0].(float64); ok {
+		ftl.Time = int64(fv)
+	} else {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid timestamp: %v", string(b))
+	}
+
+	if sv, ok := v[1].(string); ok {
+		ftl.Value = sv
+	} else {
+		return fmt.Errorf("unable to decode latest histogram value, "+
+			"invalid value: %v", string(b))
+	}
+
+	return nil
 }
 
 // NewFindTagsOption creates a new find tags option with any name and value.

--- a/tags_test.go
+++ b/tags_test.go
@@ -52,7 +52,7 @@ func TestFindTagsJSON(t *testing.T) {
 		Activity:   [][]int64{{1, 1}, {2, 1}},
 		Latest: &FindTagsLatest{
 			Numeric:   []FindTagsLatestNumeric{{1, float64Ptr(1)}},
-			Text:      []FindTagsLatestText{{1, stringPtr("test")}},
+			Text:      []FindTagsLatestText{{1, nil}},
 			Histogram: []FindTagsLatestHistogram{{1, stringPtr("AAEoAgAB")}},
 		},
 	}
@@ -78,9 +78,9 @@ func TestFindTagsJSON(t *testing.T) {
 			*fti.Latest.Numeric[0].Value, *r.Latest.Numeric[0].Value)
 	}
 
-	if *fti.Latest.Text[0].Value != *r.Latest.Text[0].Value {
-		t.Errorf("Expected text latest value: %v, got: %v",
-			*fti.Latest.Text[0].Value, *r.Latest.Text[0].Value)
+	if r.Latest.Text[0].Value != nil {
+		t.Errorf("Expected text latest value: nil, got: %v",
+			r.Latest.Text[0].Value)
 	}
 
 	if *fti.Latest.Histogram[0].Value != *r.Latest.Histogram[0].Value {

--- a/tags_test.go
+++ b/tags_test.go
@@ -47,6 +47,7 @@ func TestFindTags(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
+			w.Header().Set("X-Snowth-Search-Result-Count", "1")
 			w.Write([]byte(tagsTestData))
 			return
 		}
@@ -64,7 +65,13 @@ func TestFindTags(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.FindTags(node, 1, "test", "1", "1")
+	res, err := sc.FindTags(node, 1, "test",
+		FindTagsOptionStart("1"),
+		FindTagsOptionEnd("2"),
+		FindTagsOptionActivity("1"),
+		FindTagsOptionLatest("1"),
+		FindTagsOptionCountOnly("0"),
+		NewFindTagsOption("test", "test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +113,7 @@ func TestFindTags(t *testing.T) {
 			res.Items[0].Activity[1][1])
 	}
 
-	res, err = sc.FindTags(node, 1, "test", "", "")
+	res, err = sc.FindTags(node, 1, "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tags_test.go
+++ b/tags_test.go
@@ -51,9 +51,9 @@ func TestFindTagsJSON(t *testing.T) {
 		AccountID:  1,
 		Activity:   [][]int64{{1, 1}, {2, 1}},
 		Latest: &FindTagsLatest{
-			Numeric:   []FindTagsLatestNumeric{{1, 1}},
-			Text:      []FindTagsLatestText{{1, "test"}},
-			Histogram: []FindTagsLatestHistogram{{1, "AAEoAgAB"}},
+			Numeric:   []FindTagsLatestNumeric{{1, float64Ptr(1)}},
+			Text:      []FindTagsLatestText{{1, stringPtr("test")}},
+			Histogram: []FindTagsLatestHistogram{{1, stringPtr("AAEoAgAB")}},
 		},
 	}
 
@@ -73,19 +73,19 @@ func TestFindTagsJSON(t *testing.T) {
 		t.Fatal("Expected latest data to not be nil")
 	}
 
-	if fti.Latest.Numeric[0].Value != r.Latest.Numeric[0].Value {
+	if *fti.Latest.Numeric[0].Value != *r.Latest.Numeric[0].Value {
 		t.Errorf("Expected numeric latest value: %v, got: %v",
-			fti.Latest.Numeric[0].Value, r.Latest.Numeric[0].Value)
+			*fti.Latest.Numeric[0].Value, *r.Latest.Numeric[0].Value)
 	}
 
-	if fti.Latest.Text[0].Value != r.Latest.Text[0].Value {
+	if *fti.Latest.Text[0].Value != *r.Latest.Text[0].Value {
 		t.Errorf("Expected text latest value: %v, got: %v",
-			fti.Latest.Text[0].Value, r.Latest.Text[0].Value)
+			*fti.Latest.Text[0].Value, *r.Latest.Text[0].Value)
 	}
 
-	if fti.Latest.Histogram[0].Value != r.Latest.Histogram[0].Value {
+	if *fti.Latest.Histogram[0].Value != *r.Latest.Histogram[0].Value {
 		t.Errorf("Expected histogram latest value: %v, got: %v",
-			fti.Latest.Histogram[0].Value, r.Latest.Histogram[0].Value)
+			*fti.Latest.Histogram[0].Value, *r.Latest.Histogram[0].Value)
 	}
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 const tagsTestData = `[
@@ -121,13 +122,13 @@ func TestFindTags(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.FindTags(node, 1, "test",
-		FindTagsOptionStart("1"),
-		FindTagsOptionEnd("2"),
-		FindTagsOptionActivity("1"),
-		FindTagsOptionLatest("1"),
-		FindTagsOptionCountOnly("0"),
-		NewFindTagsOption("test", "test"))
+	res, err := sc.FindTags(node, 1, "test", &FindTagsOptions{
+		Start:     time.Unix(1, 0),
+		End:       time.Unix(2, 0),
+		Activity:  1,
+		Latest:    1,
+		CountOnly: 0,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +170,7 @@ func TestFindTags(t *testing.T) {
 			res.Items[0].Activity[1][1])
 	}
 
-	res, err = sc.FindTags(node, 1, "test")
+	res, err = sc.FindTags(node, 1, "test", &FindTagsOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Adds a new FindTagsLatest type and a new 'Latest' field to the `FindTagsItem` type to support `SnowthClient.FindTags()` returning the latest data values when requested from the IRONdb find call.
- Changes the signature of the `SnowthClient.FindTags()` and  `SnowthClient.FindTagsContext()` methods to accept a `*FindTagsOptions` argument. This argument contains the values for the supported IRONdb find operation query parameters.