### PR TITLE
CIRC-2444: Migrate updates from GoAPI into gosnowth

### DIFF
--- a/caql.go
+++ b/caql.go
@@ -26,6 +26,7 @@ type CAQLQuery struct {
 	Debug                byte     `json:"_debug,omitempty"`
 	Expansion            []string `json:"expansion,omitempty"`
 	End                  int64    `json:"end_time,omitempty"`
+	Explain              bool     `json:"explain"`
 }
 
 // CAQLErrorArgs values represent CAQL request arguments returned in an error.

--- a/df4.go
+++ b/df4.go
@@ -21,9 +21,11 @@ type DF4Meta struct {
 // DF4Head values contain information about the time range of the data elements
 // in a DF4 time series data response.
 type DF4Head struct {
-	Count   int64           `json:"count"`
-	Start   int64           `json:"start"`
-	Period  int64           `json:"period"`
+	Count  int64 `json:"count"`
+	Start  int64 `json:"start"`
+	Period int64 `json:"period"`
+	// TODO: Replace the Explain value with an actual typed schema when one
+	// becomes available.
 	Explain json.RawMessage `json:"explain,omitempty"`
 }
 

--- a/df4.go
+++ b/df4.go
@@ -1,5 +1,7 @@
 package gosnowth
 
+import "encoding/json"
+
 // DF4Response values represent time series data in the DF4 format.
 type DF4Response struct {
 	Ver  string          `json:"version,omitempty"`
@@ -19,9 +21,10 @@ type DF4Meta struct {
 // DF4Head values contain information about the time range of the data elements
 // in a DF4 time series data response.
 type DF4Head struct {
-	Count  int64 `json:"count"`
-	Start  int64 `json:"start"`
-	Period int64 `json:"period"`
+	Count   int64           `json:"count"`
+	Start   int64           `json:"start"`
+	Period  int64           `json:"period"`
+	Explain json.RawMessage `json:"explain,omitempty"`
 }
 
 // Copy returns a deep copy of the base DF4 response.
@@ -31,9 +34,10 @@ func (dr *DF4Response) Copy() *DF4Response {
 		Meta: make([]DF4Meta, len(dr.Meta)),
 		Ver:  dr.Ver,
 		Head: DF4Head{
-			Count:  dr.Head.Count,
-			Start:  dr.Head.Start,
-			Period: dr.Head.Period,
+			Count:   dr.Head.Count,
+			Start:   dr.Head.Start,
+			Period:  dr.Head.Period,
+			Explain: dr.Head.Explain,
 		},
 	}
 

--- a/df4_test.go
+++ b/df4_test.go
@@ -12,7 +12,12 @@ const testDF4Response = `{
 	"head": {
 		"count": 3,
 		"start": 0,
-		"period": 300
+		"period": 300,
+		"explain":{
+			"info":{
+				"putype":["none","number"]
+			}
+		}
 	},
 	"meta": [
 		{
@@ -76,6 +81,8 @@ func TestMarshalDF4Response(t *testing.T) {
 			Count:  3,
 			Start:  0,
 			Period: 300,
+			Explain: json.RawMessage([]byte(
+				`{"info":{"putype":["none","number"]}}`)),
 		},
 	}
 
@@ -114,5 +121,9 @@ func TestUnmarshalDF4Timeseries(t *testing.T) {
 
 	if v.Head.Period != 300 {
 		t.Errorf(`Expected time period: 300. got %d`, v.Head.Period)
+	}
+
+	if len(v.Head.Explain) != 53 {
+		t.Errorf("Expected length explain: 53, got: %v", len(v.Head.Explain))
 	}
 }


### PR DESCRIPTION
- Contains the upstream changes to the work that has been done to this library within the GoAPI project.
- Adds support for the Explain parameter and results for CAQL requests.
- Adds support for tracing and dumping request payload to stdout for diagnostic purposes.
