### PR TITLE
Linting cleanup and minor fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,54 @@
+run:
+    timeout: 10m
+    skip-dirs:
+        - pkg/pb
+    skip-files:
+        - internal/api/static.go
+    modules-download-mode: vendor
+linters-settings:
+    golint:
+        min-confidence: 0
+linters:
+    fast: true
+    enable:
+      - bodyclose
+      - deadcode
+      - depguard
+      - dogsled
+        #- dupl
+      - errcheck
+        #- funlen
+      - gochecknoglobals
+      - gochecknoinits
+        #- gocognit
+        #- goconst
+      - gocritic
+      - gocyclo
+        #- godox
+      - gofmt
+      - goimports
+      - golint
+        #- gomnd
+      - goprintffuncname
+      - gosec
+      - gosimple
+      - govet
+      - ineffassign
+      - interfacer
+      - lll
+        #- maligned
+      - misspell
+      - nakedret
+      - prealloc
+      - rowserrcheck
+      - scopelint
+      - staticcheck
+      - structcheck
+      - stylecheck
+      - typecheck
+      - unconvert
+      - unparam
+      - unused
+      - varcheck
+      - whitespace
+        #- wsl

--- a/activity.go
+++ b/activity.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -13,18 +14,20 @@ type RebuildActivityRequest struct {
 }
 
 // RebuildActivity rebuilds IRONdb activity tracking data for a list of metrics.
-func (sc *SnowthClient) RebuildActivity(node *SnowthNode, rebuildRequest []RebuildActivityRequest) (*IRONdbPutResponse, error) {
+func (sc *SnowthClient) RebuildActivity(node *SnowthNode,
+	rebuildRequest []RebuildActivityRequest) (*IRONdbPutResponse, error) {
 	return sc.RebuildActivityContext(context.Background(), node, rebuildRequest)
 }
 
 // RebuildActivityContext is the context aware version of RebuildActivity.
-func (sc *SnowthClient) RebuildActivityContext(ctx context.Context, node *SnowthNode,
+func (sc *SnowthClient) RebuildActivityContext(ctx context.Context,
+	node *SnowthNode,
 	rebuildRequest []RebuildActivityRequest) (*IRONdbPutResponse, error) {
-
 	data, err := encodeJSON(rebuildRequest)
 	if err != nil {
 		return nil, err
 	}
+
 	body, _, err := sc.do(ctx, node, "POST", "/surrogate/activity_rebuild", data, nil)
 	if err != nil {
 		return nil, err

--- a/activity_test.go
+++ b/activity_test.go
@@ -14,12 +14,12 @@ func TestRebuildActivity(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -31,18 +31,17 @@ func TestRebuildActivity(t *testing.T) {
 
 			if string(b) == "[]\n" {
 				w.WriteHeader(200)
-				w.Write([]byte(`{ "records": 0, "updated": 0, "misdirected": 0, "errors": 0 }`))
+				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, "misdirected": 0, "errors": 0 }`))
 				return
 			}
 
 			w.WriteHeader(500)
-			w.Write([]byte("invalid request body"))
+			_, _ = w.Write([]byte("invalid request body"))
 			return
 		}
 
 		t.Errorf("Unexpected request: %v", r)
 		w.WriteHeader(500)
-		return
 	}))
 
 	defer ms.Close()

--- a/activity_test.go
+++ b/activity_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/caql.go
+++ b/caql.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -69,6 +70,7 @@ func (ce *CAQLError) String() string {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
+
 	if err := enc.Encode(ce); err != nil {
 		return "unable to encode JSON: " + err.Error()
 	}
@@ -76,20 +78,20 @@ func (ce *CAQLError) String() string {
 	return buf.String()
 }
 
-// String returns this error as a JSON format string.
+// Error returns this error as a JSON format string.
 func (ce *CAQLError) Error() string {
 	return ce.String()
 }
 
 // GetCAQLQuery retrieves data values for metrics matching a CAQL format.
-func (sc *SnowthClient) GetCAQLQuery(q *CAQLQuery, nodes ...*SnowthNode) (*DF4Response, error) {
+func (sc *SnowthClient) GetCAQLQuery(q *CAQLQuery,
+	nodes ...*SnowthNode) (*DF4Response, error) {
 	return sc.GetCAQLQueryContext(context.Background(), q, nodes...)
 }
 
 // GetCAQLQueryContext is the context aware version of GetCAQLQuery.
-func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context,
-	q *CAQLQuery, nodes ...*SnowthNode) (*DF4Response, error) {
-
+func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
+	nodes ...*SnowthNode) (*DF4Response, error) {
 	node := sc.GetActiveNode()
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]

--- a/caql_test.go
+++ b/caql_test.go
@@ -40,12 +40,12 @@ func TestGetCAQLQuery(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -54,17 +54,17 @@ func TestGetCAQLQuery(t *testing.T) {
 			b, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(testCAQLError))
+				_, _ = w.Write([]byte(testCAQLError))
 				return
 			}
 
 			if strings.Contains(string(b), "histograms") {
 				w.WriteHeader(502)
-				w.Write([]byte(testCAQLError))
+				_, _ = w.Write([]byte(testCAQLError))
 				return
 			}
 
-			w.Write([]byte(testDF4Response))
+			_, _ = w.Write([]byte(testDF4Response))
 			return
 		}
 	}))

--- a/caql_test.go
+++ b/caql_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/client.go
+++ b/client.go
@@ -622,9 +622,7 @@ func (sc *SnowthClient) ListInactiveNodes() []*SnowthNode {
 	sc.RLock()
 	defer sc.RUnlock()
 	result := []*SnowthNode{}
-	for _, url := range sc.inactiveNodes {
-		result = append(result, url)
-	}
+	result = append(result, sc.inactiveNodes...)
 	return result
 }
 
@@ -633,9 +631,7 @@ func (sc *SnowthClient) ListActiveNodes() []*SnowthNode {
 	sc.RLock()
 	defer sc.RUnlock()
 	result := []*SnowthNode{}
-	for _, url := range sc.activeNodes {
-		result = append(result, url)
-	}
+	result = append(result, sc.activeNodes...)
 	return result
 }
 

--- a/client.go
+++ b/client.go
@@ -301,6 +301,7 @@ func (sc *SnowthClient) Topology() (*Topology, error) {
 	if sc.currentTopologyCompiled != nil {
 		return sc.currentTopologyCompiled, nil
 	}
+
 	var lasterr error = nil
 	for _, node := range sc.ListActiveNodes() {
 		if topology, lasterr := sc.GetTopologyInfo(node); lasterr == nil {
@@ -768,7 +769,10 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 		return nil, nil, errors.Wrap(err, "failed to perform request")
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
 	res, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to read response body")

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/client_test.go
+++ b/client_test.go
@@ -49,12 +49,12 @@ func TestSnowthClientRequest(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -63,7 +63,7 @@ func TestSnowthClientRequest(t *testing.T) {
 				t.Error("Expected X-Test-Header:test")
 			}
 
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 	}))
@@ -126,31 +126,31 @@ func TestSnowthClientDiscoverNodesWatch(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/topology/xml/") {
-			w.Write([]byte(topologyXMLTestData))
+			_, _ = w.Write([]byte(topologyXMLTestData))
 			return
 		}
 
 		if r.RequestURI == "/gossip/json" {
 			if r.Header.Get("ALT") != "" {
-				w.Write([]byte(gossipTestAltData))
+				_, _ = w.Write([]byte(gossipTestAltData))
 			}
 
-			w.Write([]byte(gossipTestData))
+			_, _ = w.Write([]byte(gossipTestData))
 			return
 		}
 	}))
@@ -247,22 +247,22 @@ func TestSnowthClientLog(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/topology/xml/") {
-			w.Write([]byte(topologyXMLTestData))
+			_, _ = w.Write([]byte(topologyXMLTestData))
 			return
 		}
 	}))
@@ -304,12 +304,12 @@ func TestSnowthClientSetWatch(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -318,7 +318,7 @@ func TestSnowthClientSetWatch(t *testing.T) {
 				t.Error("Expected X-Test-Header:test")
 			}
 
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 	}))

--- a/common.go
+++ b/common.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -107,11 +108,13 @@ func decodeXML(r io.Reader, v interface{}) error {
 	return nil
 }
 
+const million int = 1000000
+
 // formatTimestamp returns a string containing a timestamp in the format used
 // by the IRONdb API.
 func formatTimestamp(t time.Time) string {
-	if t.Nanosecond()/1000000 != 0 {
-		return fmt.Sprintf("%d.%03d", t.Unix(), t.Nanosecond()/1000000)
+	if t.Nanosecond()/million != 0 {
+		return fmt.Sprintf("%d.%03d", t.Unix(), t.Nanosecond()/million)
 	}
 
 	return fmt.Sprintf("%d", t.Unix())
@@ -136,7 +139,7 @@ func parseTimestamp(s string) (time.Time, error) {
 				s, err.Error())
 		}
 
-		nsec = nsec * 1000000
+		nsec *= int64(million)
 	}
 
 	return time.Unix(sec, nsec), nil

--- a/common_test.go
+++ b/common_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/common_test.go
+++ b/common_test.go
@@ -12,20 +12,12 @@ import (
 	"time"
 )
 
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
 func float64Ptr(f float64) *float64 {
 	return &f
 }
 
 func stringPtr(s string) *string {
 	return &s
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 type noOpReadCloser struct {

--- a/config.go
+++ b/config.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -22,11 +23,11 @@ type Config struct {
 // NewConfig creates and initializes a new SnowthClient configuration value.
 func NewConfig(servers ...string) (*Config, error) {
 	c := &Config{
-		dialTimeout:   time.Duration(500 * time.Millisecond),
+		dialTimeout:   500 * time.Millisecond,
 		discover:      false,
 		servers:       []string{},
-		timeout:       time.Duration(10 * time.Second),
-		watchInterval: time.Duration(30 * time.Second),
+		timeout:       10 * time.Second,
+		watchInterval: 30 * time.Second,
 	}
 
 	if err := c.SetServers(servers...); err != nil {
@@ -191,7 +192,7 @@ func (c *Config) Servers() []string {
 	return s
 }
 
-// SetServers assigns a new list of server addressess and returns a pointer to the
+// SetServers assigns a new list of server addresses and returns a pointer to the
 // updated configuration value.
 func (c *Config) SetServers(servers ...string) error {
 	s := []string{}

--- a/config_test.go
+++ b/config_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/df4.go
+++ b/df4.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import "encoding/json"

--- a/df4_test.go
+++ b/df4_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -97,7 +98,6 @@ func TestMarshalDF4Response(t *testing.T) {
 	if buf.String() != exp {
 		t.Errorf("Expected JSON: %s, got: %s", exp, buf.String())
 	}
-
 }
 
 func TestUnmarshalDF4Timeseries(t *testing.T) {

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -26,39 +26,35 @@ func ExampleReadNNT() {
 
 	// Write text data in order to read back the data.
 	id := uuid.New().String()
-	for _, node := range client.ListActiveNodes() {
-		// WriteNNT takes in a node and variadic of NNTPartsData entries.
-		if err := client.WriteNNT(node, gosnowth.NNTData{
-			Metric: "test-metric",
-			ID:     id,
-			Offset: (time.Now().Unix() / 60) * 60,
-			Count:  5, Value: 100,
-			Parts: gosnowth.Parts{
-				Period: 60,
-				Data: []gosnowth.NNTPartsData{
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-				}},
-		}); err != nil {
-			log.Fatalf("failed to write text data: %v", err)
-		}
-
-		data, err := client.ReadNNTValues(node,
-			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second),
-			60, "count", id, "test-metric")
-		if err != nil {
-			log.Fatalf("failed to read nnt data: %v", err)
-		}
-
-		log.Printf("%+v\n", data)
-		data1, err := client.ReadNNTAllValues(node,
-			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second),
-			60, id, "test-metric")
-		log.Printf("%+v\n", data1)
+	// WriteNNT takes in a node and variadic of NNTPartsData entries.
+	if err := client.WriteNNT([]gosnowth.NNTData{{
+		Metric: "test-metric",
+		ID:     id,
+		Offset: (time.Now().Unix() / 60) * 60,
+		Count:  5, Value: 100,
+		Parts: gosnowth.Parts{
+			Period: 60,
+			Data: []gosnowth.NNTPartsData{
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+			}},
+	}}); err != nil {
+		log.Fatalf("failed to write text data: %v", err)
 	}
+
+	data, err := client.ReadNNTValues(time.Now().Add(-60*time.Second),
+		time.Now().Add(60*time.Second), 60, "count", id, "test-metric")
+	if err != nil {
+		log.Fatalf("failed to read nnt data: %v", err)
+	}
+
+	log.Printf("%+v\n", data)
+	data1, err := client.ReadNNTAllValues(time.Now().Add(-60*time.Second),
+		time.Now().Add(60*time.Second), 60, id, "test-metric")
+	log.Printf("%+v\n", data1)
 }
 
 // ExampleReadText demonstrates how to read text values from a given snowth
@@ -77,23 +73,21 @@ func ExampleReadText() {
 	}
 
 	// Write text data in order to read back the data.
-	for _, node := range client.ListActiveNodes() {
-		id := uuid.New().String()
-		if err := client.WriteText(node, gosnowth.TextData{
-			Metric: "test-text-metric2",
-			ID:     id,
-			Offset: strconv.FormatInt(time.Now().Unix(), 10),
-			Value:  "a_text_data_value",
-		}); err != nil {
-			log.Fatalf("failed to write text data: %v", err)
-		}
-
-		data, err := client.ReadTextValues(id, "test-text-metric2",
-			time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second), node)
-		if err != nil {
-			log.Fatalf("failed to read text data: %v", err)
-		}
-
-		log.Printf("%+v\n", data)
+	id := uuid.New().String()
+	if err := client.WriteText([]gosnowth.TextData{{
+		Metric: "test-text-metric2",
+		ID:     id,
+		Offset: strconv.FormatInt(time.Now().Unix(), 10),
+		Value:  "a_text_data_value",
+	}}); err != nil {
+		log.Fatalf("failed to write text data: %v", err)
 	}
+
+	data, err := client.ReadTextValues(id, "test-text-metric2",
+		time.Now().Add(-60*time.Second), time.Now().Add(60*time.Second))
+	if err != nil {
+		log.Fatalf("failed to read text data: %v", err)
+	}
+
+	log.Printf("%+v\n", data)
 }

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -26,17 +26,15 @@ func ExampleSubmitText() {
 	}
 
 	// Write text data.
-	for _, node := range client.ListActiveNodes() {
-		id := uuid.New().String()
-		// WriteText takes in a node and variadic of TextData entries.
-		if err := client.WriteText(node, gosnowth.TextData{
-			Metric: "test-text-metric2",
-			ID:     id,
-			Offset: strconv.FormatInt(time.Now().Unix(), 10),
-			Value:  "a_text_data_value",
-		}); err != nil {
-			log.Fatalf("failed to write text data: %v", err)
-		}
+	id := uuid.New().String()
+	// WriteText takes in a node and variadic of TextData entries.
+	if err := client.WriteText([]gosnowth.TextData{{
+		Metric: "test-text-metric2",
+		ID:     id,
+		Offset: strconv.FormatInt(time.Now().Unix(), 10),
+		Value:  "a_text_data_value",
+	}}); err != nil {
+		log.Fatalf("failed to write text data: %v", err)
 	}
 }
 
@@ -55,26 +53,24 @@ func ExampleSubmitNNT() {
 	}
 
 	// Write NNT data to the node.
-	for _, node := range client.ListActiveNodes() {
-		id := uuid.New().String()
-		if err := client.WriteNNT(node, gosnowth.NNTData{
-			Metric: "test-metric",
-			ID:     id,
-			Offset: time.Now().Unix(),
-			Count:  5, Value: 100,
-			Parts: gosnowth.Parts{
-				Period: 60,
-				Data: []gosnowth.NNTPartsData{
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-					gosnowth.NNTPartsData{Count: 1, Value: 100},
-				},
+	id := uuid.New().String()
+	if err := client.WriteNNT([]gosnowth.NNTData{{
+		Metric: "test-metric",
+		ID:     id,
+		Offset: time.Now().Unix(),
+		Count:  5, Value: 100,
+		Parts: gosnowth.Parts{
+			Period: 60,
+			Data: []gosnowth.NNTPartsData{
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
+				{Count: 1, Value: 100},
 			},
-		}); err != nil {
-			log.Fatalf("failed to write nnt data: %v", err)
-		}
+		},
+	}}); err != nil {
+		log.Fatalf("failed to write nnt data: %v", err)
 	}
 }
 
@@ -102,18 +98,16 @@ func ExampleSubmitHistogram() {
 	}, false)
 
 	// Write histogram data.
-	for _, node := range client.ListActiveNodes() {
-		id := uuid.New().String()
-		if err := client.WriteHistogram(node, gosnowth.HistogramData{
-			AccountID: 1,
-			Metric:    "test-hist-metric",
-			ID:        id,
-			CheckName: "test",
-			Offset:    time.Now().Unix(),
-			Histogram: hist,
-			Period:    60,
-		}); err != nil {
-			log.Fatalf("failed to write histogram data: %v", err)
-		}
+	id := uuid.New().String()
+	if err := client.WriteHistogram([]gosnowth.HistogramData{{
+		AccountID: 1,
+		Metric:    "test-hist-metric",
+		ID:        id,
+		CheckName: "test",
+		Offset:    time.Now().Unix(),
+		Histogram: hist,
+		Period:    60,
+	}}); err != nil {
+		log.Fatalf("failed to write histogram data: %v", err)
 	}
 }

--- a/fb/fetch/circonus_df4_generated.go
+++ b/fb/fetch/circonus_df4_generated.go
@@ -42,7 +42,7 @@ func (v Kind) String() string {
 }
 
 type SeriesT struct {
-	Type Series
+	Type  Series
 	Value interface{}
 }
 
@@ -65,13 +65,13 @@ func SeriesUnPack(t Series, table flatbuffers.Table) *SeriesT {
 	switch t {
 	case SeriesNumericSeries:
 		x := NumericSeries{_tab: table}
-		return &SeriesT{ Type: SeriesNumericSeries, Value: x.UnPack() }
+		return &SeriesT{Type: SeriesNumericSeries, Value: x.UnPack()}
 	case SeriesHistSeries:
 		x := HistSeries{_tab: table}
-		return &SeriesT{ Type: SeriesHistSeries, Value: x.UnPack() }
+		return &SeriesT{Type: SeriesHistSeries, Value: x.UnPack()}
 	case SeriesTextSeries:
 		x := TextSeries{_tab: table}
-		return &SeriesT{ Type: SeriesTextSeries, Value: x.UnPack() }
+		return &SeriesT{Type: SeriesTextSeries, Value: x.UnPack()}
 	}
 	return nil
 }
@@ -111,7 +111,9 @@ type HistSeriesT struct {
 }
 
 func HistSeriesPack(builder *flatbuffers.Builder, t *HistSeriesT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	valuesOffset := flatbuffers.UOffsetT(0)
 	if t.Values != nil {
 		valuesLength := len(t.Values)
@@ -131,7 +133,9 @@ func HistSeriesPack(builder *flatbuffers.Builder, t *HistSeriesT) flatbuffers.UO
 }
 
 func (rcv *HistSeries) UnPack() *HistSeriesT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &HistSeriesT{}
 	valuesLength := rcv.ValuesLength()
 	t.Values = make([]*HistogramT, valuesLength)
@@ -195,13 +199,16 @@ func HistSeriesStartValuesVector(builder *flatbuffers.Builder, numElems int) fla
 func HistSeriesEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type TextEntryT struct {
 	InternalOffsetMs uint64
-	Value string
+	Value            string
 }
 
 func TextEntryPack(builder *flatbuffers.Builder, t *TextEntryT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	valueOffset := builder.CreateString(t.Value)
 	TextEntryStart(builder)
 	TextEntryAddInternalOffsetMs(builder, t.InternalOffsetMs)
@@ -210,7 +217,9 @@ func TextEntryPack(builder *flatbuffers.Builder, t *TextEntryT) flatbuffers.UOff
 }
 
 func (rcv *TextEntry) UnPack() *TextEntryT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &TextEntryT{}
 	t.InternalOffsetMs = rcv.InternalOffsetMs()
 	t.Value = string(rcv.Value())
@@ -269,12 +278,15 @@ func TextEntryAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT)
 func TextEntryEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type TextMultiValueT struct {
 	Entries []*TextEntryT
 }
 
 func TextMultiValuePack(builder *flatbuffers.Builder, t *TextMultiValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	entriesOffset := flatbuffers.UOffsetT(0)
 	if t.Entries != nil {
 		entriesLength := len(t.Entries)
@@ -294,7 +306,9 @@ func TextMultiValuePack(builder *flatbuffers.Builder, t *TextMultiValueT) flatbu
 }
 
 func (rcv *TextMultiValue) UnPack() *TextMultiValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &TextMultiValueT{}
 	entriesLength := rcv.EntriesLength()
 	t.Entries = make([]*TextEntryT, entriesLength)
@@ -358,12 +372,15 @@ func TextMultiValueStartEntriesVector(builder *flatbuffers.Builder, numElems int
 func TextMultiValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type TextSeriesT struct {
 	Values []*TextMultiValueT
 }
 
 func TextSeriesPack(builder *flatbuffers.Builder, t *TextSeriesT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	valuesOffset := flatbuffers.UOffsetT(0)
 	if t.Values != nil {
 		valuesLength := len(t.Values)
@@ -383,7 +400,9 @@ func TextSeriesPack(builder *flatbuffers.Builder, t *TextSeriesT) flatbuffers.UO
 }
 
 func (rcv *TextSeries) UnPack() *TextSeriesT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &TextSeriesT{}
 	valuesLength := rcv.ValuesLength()
 	t.Values = make([]*TextMultiValueT, valuesLength)
@@ -447,12 +466,15 @@ func TextSeriesStartValuesVector(builder *flatbuffers.Builder, numElems int) fla
 func TextSeriesEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type NumericSeriesT struct {
 	Values []float64
 }
 
 func NumericSeriesPack(builder *flatbuffers.Builder, t *NumericSeriesT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	valuesOffset := flatbuffers.UOffsetT(0)
 	if t.Values != nil {
 		valuesLength := len(t.Values)
@@ -468,7 +490,9 @@ func NumericSeriesPack(builder *flatbuffers.Builder, t *NumericSeriesT) flatbuff
 }
 
 func (rcv *NumericSeries) UnPack() *NumericSeriesT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &NumericSeriesT{}
 	valuesLength := rcv.ValuesLength()
 	t.Values = make([]float64, valuesLength)
@@ -536,13 +560,16 @@ func NumericSeriesStartValuesVector(builder *flatbuffers.Builder, numElems int) 
 func NumericSeriesEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type SeriesContainerT struct {
 	Kind Kind
 	Data *SeriesT
 }
 
 func SeriesContainerPack(builder *flatbuffers.Builder, t *SeriesContainerT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	dataOffset := SeriesPack(builder, t.Data)
 
 	SeriesContainerStart(builder)
@@ -555,7 +582,9 @@ func SeriesContainerPack(builder *flatbuffers.Builder, t *SeriesContainerT) flat
 }
 
 func (rcv *SeriesContainer) UnPack() *SeriesContainerT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &SeriesContainerT{}
 	t.Kind = rcv.Kind()
 	dataTable := flatbuffers.Table{}
@@ -633,13 +662,16 @@ func SeriesContainerAddData(builder *flatbuffers.Builder, data flatbuffers.UOffs
 func SeriesContainerEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type KVPairT struct {
-	Key string
+	Key   string
 	Value string
 }
 
 func KVPairPack(builder *flatbuffers.Builder, t *KVPairT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	keyOffset := builder.CreateString(t.Key)
 	valueOffset := builder.CreateString(t.Value)
 	KVPairStart(builder)
@@ -649,7 +681,9 @@ func KVPairPack(builder *flatbuffers.Builder, t *KVPairT) flatbuffers.UOffsetT {
 }
 
 func (rcv *KVPair) UnPack() *KVPairT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &KVPairT{}
 	t.Key = string(rcv.Key())
 	t.Value = string(rcv.Value())
@@ -704,17 +738,20 @@ func KVPairAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) {
 func KVPairEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type GlobalMetaDataT struct {
-	StartMs uint64
+	StartMs  uint64
 	PeriodMs uint32
-	Count uint32
-	Error []string
-	Warning []string
-	Meta []*KVPairT
+	Count    uint32
+	Error    []string
+	Warning  []string
+	Meta     []*KVPairT
 }
 
 func GlobalMetaDataPack(builder *flatbuffers.Builder, t *GlobalMetaDataT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	errorOffset := flatbuffers.UOffsetT(0)
 	if t.Error != nil {
 		errorLength := len(t.Error)
@@ -765,7 +802,9 @@ func GlobalMetaDataPack(builder *flatbuffers.Builder, t *GlobalMetaDataT) flatbu
 }
 
 func (rcv *GlobalMetaData) UnPack() *GlobalMetaDataT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &GlobalMetaDataT{}
 	t.StartMs = rcv.StartMs()
 	t.PeriodMs = rcv.PeriodMs()
@@ -933,13 +972,16 @@ func GlobalMetaDataStartMetaVector(builder *flatbuffers.Builder, numElems int) f
 func GlobalMetaDataEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type ColumnMetaDataT struct {
 	Label string
-	Meta []*KVPairT
+	Meta  []*KVPairT
 }
 
 func ColumnMetaDataPack(builder *flatbuffers.Builder, t *ColumnMetaDataT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	labelOffset := builder.CreateString(t.Label)
 	metaOffset := flatbuffers.UOffsetT(0)
 	if t.Meta != nil {
@@ -961,7 +1003,9 @@ func ColumnMetaDataPack(builder *flatbuffers.Builder, t *ColumnMetaDataT) flatbu
 }
 
 func (rcv *ColumnMetaData) UnPack() *ColumnMetaDataT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &ColumnMetaDataT{}
 	t.Label = string(rcv.Label())
 	metaLength := rcv.MetaLength()
@@ -1037,15 +1081,18 @@ func ColumnMetaDataStartMetaVector(builder *flatbuffers.Builder, numElems int) f
 func ColumnMetaDataEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type DF4T struct {
 	Version uint32
-	Head *GlobalMetaDataT
-	Meta []*ColumnMetaDataT
+	Head    *GlobalMetaDataT
+	Meta    []*ColumnMetaDataT
 	Columns []*SeriesContainerT
 }
 
 func DF4Pack(builder *flatbuffers.Builder, t *DF4T) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	headOffset := GlobalMetaDataPack(builder, t.Head)
 	metaOffset := flatbuffers.UOffsetT(0)
 	if t.Meta != nil {
@@ -1082,7 +1129,9 @@ func DF4Pack(builder *flatbuffers.Builder, t *DF4T) flatbuffers.UOffsetT {
 }
 
 func (rcv *DF4) UnPack() *DF4T {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &DF4T{}
 	t.Version = rcv.Version()
 	t.Head = rcv.Head(nil).UnPack()

--- a/fb/fetch/circonus_fetch_generated.go
+++ b/fb/fetch/circonus_fetch_generated.go
@@ -7,13 +7,15 @@ import (
 )
 
 type ReduceRequestT struct {
-	Label string
-	Method string
+	Label        string
+	Method       string
 	MethodParams []string
 }
 
 func ReduceRequestPack(builder *flatbuffers.Builder, t *ReduceRequestT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	labelOffset := builder.CreateString(t.Label)
 	methodOffset := builder.CreateString(t.Method)
 	methodParamsOffset := flatbuffers.UOffsetT(0)
@@ -37,7 +39,9 @@ func ReduceRequestPack(builder *flatbuffers.Builder, t *ReduceRequestT) flatbuff
 }
 
 func (rcv *ReduceRequest) UnPack() *ReduceRequestT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &ReduceRequestT{}
 	t.Label = string(rcv.Label())
 	t.Method = string(rcv.Method())
@@ -120,17 +124,20 @@ func ReduceRequestStartMethodParamsVector(builder *flatbuffers.Builder, numElems
 func ReduceRequestEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type StreamRequestT struct {
-	CheckUuid []byte
-	Name string
-	Kind Kind
-	Transform string
+	CheckUuid       []byte
+	Name            string
+	Kind            Kind
+	Transform       string
 	TransformParams []string
-	Label string
+	Label           string
 }
 
 func StreamRequestPack(builder *flatbuffers.Builder, t *StreamRequestT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	checkUuidOffset := flatbuffers.UOffsetT(0)
 	if t.CheckUuid != nil {
 		checkUuidOffset = builder.CreateByteString(t.CheckUuid)
@@ -162,7 +169,9 @@ func StreamRequestPack(builder *flatbuffers.Builder, t *StreamRequestT) flatbuff
 }
 
 func (rcv *StreamRequest) UnPack() *StreamRequestT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &StreamRequestT{}
 	t.CheckUuid = rcv.CheckUuidBytes()
 	t.Name = string(rcv.Name())
@@ -314,16 +323,19 @@ func StreamRequestAddLabel(builder *flatbuffers.Builder, label flatbuffers.UOffs
 func StreamRequestEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type FetchT struct {
-	StartMs uint64
+	StartMs  uint64
 	PeriodMs uint32
-	Count uint32
-	Streams []*StreamRequestT
-	Reduce []*ReduceRequestT
+	Count    uint32
+	Streams  []*StreamRequestT
+	Reduce   []*ReduceRequestT
 }
 
 func FetchPack(builder *flatbuffers.Builder, t *FetchT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	streamsOffset := flatbuffers.UOffsetT(0)
 	if t.Streams != nil {
 		streamsLength := len(t.Streams)
@@ -360,7 +372,9 @@ func FetchPack(builder *flatbuffers.Builder, t *FetchT) flatbuffers.UOffsetT {
 }
 
 func (rcv *Fetch) UnPack() *FetchT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &FetchT{}
 	t.StartMs = rcv.StartMs()
 	t.PeriodMs = rcv.PeriodMs()

--- a/fb/fetch/metric_hist_generated.go
+++ b/fb/fetch/metric_hist_generated.go
@@ -7,13 +7,15 @@ import (
 )
 
 type HistogramBucketT struct {
-	Val int8
-	Exp int8
+	Val   int8
+	Exp   int8
 	Count uint64
 }
 
 func HistogramBucketPack(builder *flatbuffers.Builder, t *HistogramBucketT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	HistogramBucketStart(builder)
 	HistogramBucketAddVal(builder, t.Val)
 	HistogramBucketAddExp(builder, t.Exp)
@@ -22,7 +24,9 @@ func HistogramBucketPack(builder *flatbuffers.Builder, t *HistogramBucketT) flat
 }
 
 func (rcv *HistogramBucket) UnPack() *HistogramBucketT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &HistogramBucketT{}
 	t.Val = rcv.Val()
 	t.Exp = rcv.Exp()
@@ -101,12 +105,15 @@ func HistogramBucketAddCount(builder *flatbuffers.Builder, count uint64) {
 func HistogramBucketEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type HistogramT struct {
 	Buckets []*HistogramBucketT
 }
 
 func HistogramPack(builder *flatbuffers.Builder, t *HistogramT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	bucketsOffset := flatbuffers.UOffsetT(0)
 	if t.Buckets != nil {
 		bucketsLength := len(t.Buckets)
@@ -126,7 +133,9 @@ func HistogramPack(builder *flatbuffers.Builder, t *HistogramT) flatbuffers.UOff
 }
 
 func (rcv *Histogram) UnPack() *HistogramT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &HistogramT{}
 	bucketsLength := rcv.BucketsLength()
 	t.Buckets = make([]*HistogramBucketT, bucketsLength)
@@ -190,14 +199,17 @@ func HistogramStartBucketsVector(builder *flatbuffers.Builder, numElems int) fla
 func HistogramEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type MetricHistogramResultT struct {
 	Timestamp uint64
-	Period int32
+	Period    int32
 	Histogram *HistogramT
 }
 
 func MetricHistogramResultPack(builder *flatbuffers.Builder, t *MetricHistogramResultT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	histogramOffset := HistogramPack(builder, t.Histogram)
 	MetricHistogramResultStart(builder)
 	MetricHistogramResultAddTimestamp(builder, t.Timestamp)
@@ -207,7 +219,9 @@ func MetricHistogramResultPack(builder *flatbuffers.Builder, t *MetricHistogramR
 }
 
 func (rcv *MetricHistogramResult) UnPack() *MetricHistogramResultT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricHistogramResultT{}
 	t.Timestamp = rcv.Timestamp()
 	t.Period = rcv.Period()
@@ -287,12 +301,15 @@ func MetricHistogramResultAddHistogram(builder *flatbuffers.Builder, histogram f
 func MetricHistogramResultEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type MetricHistogramResultListT struct {
 	Results []*MetricHistogramResultT
 }
 
 func MetricHistogramResultListPack(builder *flatbuffers.Builder, t *MetricHistogramResultListT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	resultsOffset := flatbuffers.UOffsetT(0)
 	if t.Results != nil {
 		resultsLength := len(t.Results)
@@ -312,7 +329,9 @@ func MetricHistogramResultListPack(builder *flatbuffers.Builder, t *MetricHistog
 }
 
 func (rcv *MetricHistogramResultList) UnPack() *MetricHistogramResultListT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricHistogramResultListT{}
 	resultsLength := rcv.ResultsLength()
 	t.Results = make([]*MetricHistogramResultT, resultsLength)

--- a/fb/noit/metric_batch_generated.go
+++ b/fb/noit/metric_batch_generated.go
@@ -11,11 +11,13 @@ type MetricBatchT struct {
 	CheckName string
 	CheckUuid string
 	AccountId int32
-	Metrics []*MetricValueT
+	Metrics   []*MetricValueT
 }
 
 func MetricBatchPack(builder *flatbuffers.Builder, t *MetricBatchT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	checkNameOffset := builder.CreateString(t.CheckName)
 	checkUuidOffset := builder.CreateString(t.CheckUuid)
 	metricsOffset := flatbuffers.UOffsetT(0)
@@ -41,7 +43,9 @@ func MetricBatchPack(builder *flatbuffers.Builder, t *MetricBatchT) flatbuffers.
 }
 
 func (rcv *MetricBatch) UnPack() *MetricBatchT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricBatchT{}
 	t.Timestamp = rcv.Timestamp()
 	t.CheckName = string(rcv.CheckName())

--- a/fb/noit/metric_common_generated.go
+++ b/fb/noit/metric_common_generated.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MetricValueUnionT struct {
-	Type MetricValueUnion
+	Type  MetricValueUnion
 	Value interface{}
 }
 
@@ -46,34 +46,34 @@ func MetricValueUnionUnPack(t MetricValueUnion, table flatbuffers.Table) *Metric
 	switch t {
 	case MetricValueUnionIntValue:
 		x := IntValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionIntValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionIntValue, Value: x.UnPack()}
 	case MetricValueUnionUintValue:
 		x := UintValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionUintValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionUintValue, Value: x.UnPack()}
 	case MetricValueUnionLongValue:
 		x := LongValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionLongValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionLongValue, Value: x.UnPack()}
 	case MetricValueUnionUlongValue:
 		x := UlongValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionUlongValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionUlongValue, Value: x.UnPack()}
 	case MetricValueUnionDoubleValue:
 		x := DoubleValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionDoubleValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionDoubleValue, Value: x.UnPack()}
 	case MetricValueUnionStringValue:
 		x := StringValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionStringValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionStringValue, Value: x.UnPack()}
 	case MetricValueUnionHistogram:
 		x := Histogram{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionHistogram, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionHistogram, Value: x.UnPack()}
 	case MetricValueUnionAbsentNumericValue:
 		x := AbsentNumericValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionAbsentNumericValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionAbsentNumericValue, Value: x.UnPack()}
 	case MetricValueUnionAbsentStringValue:
 		x := AbsentStringValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionAbsentStringValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionAbsentStringValue, Value: x.UnPack()}
 	case MetricValueUnionAbsentHistogramValue:
 		x := AbsentHistogramValue{_tab: table}
-		return &MetricValueUnionT{ Type: MetricValueUnionAbsentHistogramValue, Value: x.UnPack() }
+		return &MetricValueUnionT{Type: MetricValueUnionAbsentHistogramValue, Value: x.UnPack()}
 	}
 	return nil
 }
@@ -134,14 +134,18 @@ type IntValueT struct {
 }
 
 func IntValuePack(builder *flatbuffers.Builder, t *IntValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	IntValueStart(builder)
 	IntValueAddValue(builder, t.Value)
 	return IntValueEnd(builder)
 }
 
 func (rcv *IntValue) UnPack() *IntValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &IntValueT{}
 	t.Value = rcv.Value()
 	return t
@@ -188,19 +192,24 @@ func IntValueAddValue(builder *flatbuffers.Builder, value int32) {
 func IntValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type UintValueT struct {
 	Value uint32
 }
 
 func UintValuePack(builder *flatbuffers.Builder, t *UintValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	UintValueStart(builder)
 	UintValueAddValue(builder, t.Value)
 	return UintValueEnd(builder)
 }
 
 func (rcv *UintValue) UnPack() *UintValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &UintValueT{}
 	t.Value = rcv.Value()
 	return t
@@ -247,19 +256,24 @@ func UintValueAddValue(builder *flatbuffers.Builder, value uint32) {
 func UintValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type LongValueT struct {
 	Value int64
 }
 
 func LongValuePack(builder *flatbuffers.Builder, t *LongValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	LongValueStart(builder)
 	LongValueAddValue(builder, t.Value)
 	return LongValueEnd(builder)
 }
 
 func (rcv *LongValue) UnPack() *LongValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &LongValueT{}
 	t.Value = rcv.Value()
 	return t
@@ -306,19 +320,24 @@ func LongValueAddValue(builder *flatbuffers.Builder, value int64) {
 func LongValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type UlongValueT struct {
 	Value uint64
 }
 
 func UlongValuePack(builder *flatbuffers.Builder, t *UlongValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	UlongValueStart(builder)
 	UlongValueAddValue(builder, t.Value)
 	return UlongValueEnd(builder)
 }
 
 func (rcv *UlongValue) UnPack() *UlongValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &UlongValueT{}
 	t.Value = rcv.Value()
 	return t
@@ -365,19 +384,24 @@ func UlongValueAddValue(builder *flatbuffers.Builder, value uint64) {
 func UlongValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type DoubleValueT struct {
 	Value float64
 }
 
 func DoubleValuePack(builder *flatbuffers.Builder, t *DoubleValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	DoubleValueStart(builder)
 	DoubleValueAddValue(builder, t.Value)
 	return DoubleValueEnd(builder)
 }
 
 func (rcv *DoubleValue) UnPack() *DoubleValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &DoubleValueT{}
 	t.Value = rcv.Value()
 	return t
@@ -424,12 +448,15 @@ func DoubleValueAddValue(builder *flatbuffers.Builder, value float64) {
 func DoubleValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type StringValueT struct {
 	Value string
 }
 
 func StringValuePack(builder *flatbuffers.Builder, t *StringValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	valueOffset := builder.CreateString(t.Value)
 	StringValueStart(builder)
 	StringValueAddValue(builder, valueOffset)
@@ -437,7 +464,9 @@ func StringValuePack(builder *flatbuffers.Builder, t *StringValueT) flatbuffers.
 }
 
 func (rcv *StringValue) UnPack() *StringValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &StringValueT{}
 	t.Value = string(rcv.Value())
 	return t
@@ -480,17 +509,22 @@ func StringValueAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffset
 func StringValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type AbsentNumericValueT struct {
 }
 
 func AbsentNumericValuePack(builder *flatbuffers.Builder, t *AbsentNumericValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	AbsentNumericValueStart(builder)
 	return AbsentNumericValueEnd(builder)
 }
 
 func (rcv *AbsentNumericValue) UnPack() *AbsentNumericValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &AbsentNumericValueT{}
 	return t
 }
@@ -521,17 +555,22 @@ func AbsentNumericValueStart(builder *flatbuffers.Builder) {
 func AbsentNumericValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type AbsentStringValueT struct {
 }
 
 func AbsentStringValuePack(builder *flatbuffers.Builder, t *AbsentStringValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	AbsentStringValueStart(builder)
 	return AbsentStringValueEnd(builder)
 }
 
 func (rcv *AbsentStringValue) UnPack() *AbsentStringValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &AbsentStringValueT{}
 	return t
 }
@@ -562,17 +601,22 @@ func AbsentStringValueStart(builder *flatbuffers.Builder) {
 func AbsentStringValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type AbsentHistogramValueT struct {
 }
 
 func AbsentHistogramValuePack(builder *flatbuffers.Builder, t *AbsentHistogramValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	AbsentHistogramValueStart(builder)
 	return AbsentHistogramValueEnd(builder)
 }
 
 func (rcv *AbsentHistogramValue) UnPack() *AbsentHistogramValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &AbsentHistogramValueT{}
 	return t
 }
@@ -603,14 +647,17 @@ func AbsentHistogramValueStart(builder *flatbuffers.Builder) {
 func AbsentHistogramValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type HistogramBucketT struct {
-	Val int8
-	Exp int8
+	Val   int8
+	Exp   int8
 	Count uint64
 }
 
 func HistogramBucketPack(builder *flatbuffers.Builder, t *HistogramBucketT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	HistogramBucketStart(builder)
 	HistogramBucketAddVal(builder, t.Val)
 	HistogramBucketAddExp(builder, t.Exp)
@@ -619,7 +666,9 @@ func HistogramBucketPack(builder *flatbuffers.Builder, t *HistogramBucketT) flat
 }
 
 func (rcv *HistogramBucket) UnPack() *HistogramBucketT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &HistogramBucketT{}
 	t.Val = rcv.Val()
 	t.Exp = rcv.Exp()
@@ -698,13 +747,16 @@ func HistogramBucketAddCount(builder *flatbuffers.Builder, count uint64) {
 func HistogramBucketEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type HistogramT struct {
-	Buckets []*HistogramBucketT
+	Buckets    []*HistogramBucketT
 	Cumulative bool
 }
 
 func HistogramPack(builder *flatbuffers.Builder, t *HistogramT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	bucketsOffset := flatbuffers.UOffsetT(0)
 	if t.Buckets != nil {
 		bucketsLength := len(t.Buckets)
@@ -725,7 +777,9 @@ func HistogramPack(builder *flatbuffers.Builder, t *HistogramT) flatbuffers.UOff
 }
 
 func (rcv *Histogram) UnPack() *HistogramT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &HistogramT{}
 	bucketsLength := rcv.BucketsLength()
 	t.Buckets = make([]*HistogramBucketT, bucketsLength)
@@ -805,16 +859,19 @@ func HistogramAddCumulative(builder *flatbuffers.Builder, cumulative bool) {
 func HistogramEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
+
 type MetricValueT struct {
-	Name string
-	Timestamp uint64
-	Value *MetricValueUnionT
+	Name       string
+	Timestamp  uint64
+	Value      *MetricValueUnionT
 	Generation int16
 	StreamTags []string
 }
 
 func MetricValuePack(builder *flatbuffers.Builder, t *MetricValueT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	nameOffset := builder.CreateString(t.Name)
 	valueOffset := MetricValueUnionPack(builder, t.Value)
 
@@ -844,7 +901,9 @@ func MetricValuePack(builder *flatbuffers.Builder, t *MetricValueT) flatbuffers.
 }
 
 func (rcv *MetricValue) UnPack() *MetricValueT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricValueT{}
 	t.Name = string(rcv.Name())
 	t.Timestamp = rcv.Timestamp()

--- a/fb/noit/metric_generated.go
+++ b/fb/noit/metric_generated.go
@@ -11,11 +11,13 @@ type MetricT struct {
 	CheckName string
 	CheckUuid string
 	AccountId int32
-	Value *MetricValueT
+	Value     *MetricValueT
 }
 
 func MetricPack(builder *flatbuffers.Builder, t *MetricT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	checkNameOffset := builder.CreateString(t.CheckName)
 	checkUuidOffset := builder.CreateString(t.CheckUuid)
 	valueOffset := MetricValuePack(builder, t.Value)
@@ -29,7 +31,9 @@ func MetricPack(builder *flatbuffers.Builder, t *MetricT) flatbuffers.UOffsetT {
 }
 
 func (rcv *Metric) UnPack() *MetricT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricT{}
 	t.Timestamp = rcv.Timestamp()
 	t.CheckName = string(rcv.CheckName())

--- a/fb/noit/metric_list_generated.go
+++ b/fb/noit/metric_list_generated.go
@@ -11,7 +11,9 @@ type MetricListT struct {
 }
 
 func MetricListPack(builder *flatbuffers.Builder, t *MetricListT) flatbuffers.UOffsetT {
-	if t == nil { return 0 }
+	if t == nil {
+		return 0
+	}
 	metricsOffset := flatbuffers.UOffsetT(0)
 	if t.Metrics != nil {
 		metricsLength := len(t.Metrics)
@@ -31,7 +33,9 @@ func MetricListPack(builder *flatbuffers.Builder, t *MetricListT) flatbuffers.UO
 }
 
 func (rcv *MetricList) UnPack() *MetricListT {
-	if rcv == nil { return nil }
+	if rcv == nil {
+		return nil
+	}
 	t := &MetricListT{}
 	metricsLength := rcv.MetricsLength()
 	t.Metrics = make([]*MetricT, metricsLength)

--- a/fetch.go
+++ b/fetch.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -55,18 +55,18 @@ func TestFetchQuery(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI,
 			"/fetch") {
-			w.Write([]byte(testDF4Response))
+			_, _ = w.Write([]byte(testDF4Response))
 			return
 		}
 	}))

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/gossip.go
+++ b/gossip.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -135,17 +135,17 @@ func TestGetGossipInfo(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if r.RequestURI == "/gossip/json" {
-			w.Write([]byte(gossipTestData))
+			_, _ = w.Write([]byte(gossipTestData))
 			return
 		}
 	}))
@@ -192,7 +192,7 @@ func TestGetGossipInfo(t *testing.T) {
 	}
 
 	cancel()
-	res, err = sc.GetGossipInfoContext(ctx, node)
+	_, err = sc.GetGossipInfoContext(ctx, node)
 	if err == nil || !strings.Contains(err.Error(), "context") {
 		t.Error("Expected context error.", err)
 	}

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -195,7 +196,7 @@ func TestWriteHistogram(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	err = sc.WriteHistogram(node, v...)
+	err = sc.WriteHistogram(v, node)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -84,19 +84,19 @@ func TestReadHistogramValues(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		u := "/histogram/1556290800/1556291400/300/" +
 			"ae0f7f90-2a6b-481c-9cf5-21a31837020e/example1"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.Write([]byte(histogramTestData))
+			_, _ = w.Write([]byte(histogramTestData))
 			return
 		}
 	}))
@@ -142,12 +142,12 @@ func TestWriteHistogram(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -172,7 +172,7 @@ func TestWriteHistogram(t *testing.T) {
 				return
 			}
 
-			w.Write([]byte(histTestData))
+			_, _ = w.Write([]byte(histTestData))
 			return
 		}
 	}))

--- a/location.go
+++ b/location.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/location_test.go
+++ b/location_test.go
@@ -40,18 +40,18 @@ func TestLocateMetric(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI,
 			"/locate/xml/1f846f26-0cfd-4df5-b4f1-e0930604e577/test") {
-			w.Write([]byte(locateXMLTestData))
+			_, _ = w.Write([]byte(locateXMLTestData))
 			return
 		}
 	}))

--- a/location_test.go
+++ b/location_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/lua.go
+++ b/lua.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -34,7 +35,7 @@ type LuaExtension struct {
 type LuaExtensions map[string]*LuaExtension
 
 // UnmarshalJSON decodes a byte slice of JSON data into a LuaExtensions map.
-func (le *LuaExtensions) UnmarshalJSON(b []byte) error {
+func (le *LuaExtensions) UnmarshalJSON(b []byte) error { // nolint gocyclo
 	r := map[string]interface{}{}
 	err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&r)
 	if err != nil {

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -169,7 +170,7 @@ func TestExecLuaExtensionContext(t *testing.T) {
 
 	node := &SnowthNode{url: u}
 	res, err := sc.ExecLuaExtension("test",
-		[]ExtParam{ExtParam{Name: "test", Value: "1"}}, node)
+		[]ExtParam{{Name: "test", Value: "1"}}, node)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lua_test.go
+++ b/lua_test.go
@@ -61,17 +61,17 @@ func TestGetLuaExtension(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/extension/lua") {
-			w.Write([]byte(testLuaExtensionData))
+			_, _ = w.Write([]byte(testLuaExtensionData))
 			return
 		}
 	}))
@@ -139,18 +139,18 @@ func TestExecLuaExtensionContext(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/extension/lua/test") {
 			if r.URL.Query().Get("test") == "1" {
-				w.Write([]byte(`{"test":1}`))
+				_, _ = w.Write([]byte(`{"test":1}`))
 				return
 			}
 		}

--- a/nnt_test.go
+++ b/nnt_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -169,9 +170,9 @@ func TestNNTReadWrite(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	res, err := sc.ReadNNTValues(node, time.Unix(1529509020, 0),
+	res, err := sc.ReadNNTValues(time.Unix(1529509020, 0),
 		time.Unix(1529509200, 0), 1, "count",
-		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "test")
+		"fc85e0ab-f568-45e6-86ee-d7443be8277d", "test", node)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,9 +185,9 @@ func TestNNTReadWrite(t *testing.T) {
 		t.Errorf("Expected value: 50, got: %v", res[0].Value)
 	}
 
-	resA, err := sc.ReadNNTAllValues(node, time.Unix(1529509020, 0),
+	resA, err := sc.ReadNNTAllValues(time.Unix(1529509020, 0),
 		time.Unix(1529509200, 0), 1, "fc85e0ab-f568-45e6-86ee-d7443be8277d",
-		"test")
+		"test", node)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +206,7 @@ func TestNNTReadWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = sc.WriteNNT(node, nv...)
+	err = sc.WriteNNT(nv, node)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nnt_test.go
+++ b/nnt_test.go
@@ -127,26 +127,26 @@ func TestNNTReadWrite(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		u := "/read/1529509020/1529509200/1/" +
 			"fc85e0ab-f568-45e6-86ee-d7443be8277d/count/test"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.Write([]byte(nntTestData))
+			_, _ = w.Write([]byte(nntTestData))
 			return
 		}
 
 		u = "/read/1529509020/1529509200/1/" +
 			"fc85e0ab-f568-45e6-86ee-d7443be8277d/all/test"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.Write([]byte(nntTestAllData))
+			_, _ = w.Write([]byte(nntTestAllData))
 			return
 		}
 

--- a/raw.go
+++ b/raw.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -59,14 +60,17 @@ type RawNumericValue struct {
 
 // ReadRawNumericValues reads raw numeric data from a node.
 func (sc *SnowthClient) ReadRawNumericValues(start time.Time, end time.Time,
-	uuid string, metric string, nodes ...*SnowthNode) ([]RawNumericValue, error) {
-	return sc.ReadRawNumericValuesContext(context.Background(), start, end, uuid, metric, nodes...)
+	uuid string, metric string,
+	nodes ...*SnowthNode) ([]RawNumericValue, error) {
+	return sc.ReadRawNumericValuesContext(context.Background(), start, end,
+		uuid, metric, nodes...)
 }
 
-// ReadRawNumericValuesContext is the context aware version of ReadRawNumericValues.
+// ReadRawNumericValuesContext is the context aware version of
+// ReadRawNumericValues.
 func (sc *SnowthClient) ReadRawNumericValuesContext(ctx context.Context,
-	start, end time.Time, uuid string, metric string, nodes ...*SnowthNode) ([]RawNumericValue, error) {
-
+	start, end time.Time, uuid, metric string,
+	nodes ...*SnowthNode) ([]RawNumericValue, error) {
 	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
@@ -97,8 +101,8 @@ func (sc *SnowthClient) WriteRaw(data io.Reader,
 
 // WriteRawContext is the context aware version of WriteRaw.
 func (sc *SnowthClient) WriteRawContext(ctx context.Context,
-	data io.Reader, fb bool, dataPoints uint64, nodes ...*SnowthNode) (*IRONdbPutResponse, error) {
-
+	data io.Reader, fb bool, dataPoints uint64,
+	nodes ...*SnowthNode) (*IRONdbPutResponse, error) {
 	node := sc.GetActiveNode()
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
@@ -122,8 +126,6 @@ func (sc *SnowthClient) WriteRawContext(ctx context.Context,
 	return r, nil
 }
 
-var metricListFileIdentifier = []byte("CIML")
-
 // WriteRawMetricList writes raw IRONdb data to a node with FlatBuffers.
 func (sc *SnowthClient) WriteRawMetricList(metricList *noit.MetricListT,
 	builder *flatbuffers.Builder, nodes ...*SnowthNode) (*IRONdbPutResponse, error) {
@@ -132,8 +134,8 @@ func (sc *SnowthClient) WriteRawMetricList(metricList *noit.MetricListT,
 
 // WriteRawMetricListContext is the context aware version of WriteRawMetricList.
 func (sc *SnowthClient) WriteRawMetricListContext(ctx context.Context,
-	metricList *noit.MetricListT, builder *flatbuffers.Builder, nodes ...*SnowthNode) (*IRONdbPutResponse, error) {
-
+	metricList *noit.MetricListT, builder *flatbuffers.Builder,
+	nodes ...*SnowthNode) (*IRONdbPutResponse, error) {
 	if metricList == nil {
 		return nil, fmt.Errorf("metric list cannot be nil")
 	}
@@ -147,7 +149,7 @@ func (sc *SnowthClient) WriteRawMetricListContext(ctx context.Context,
 		builder.Reset()
 	}
 	offset := noit.MetricListPack(builder, metricList)
-	builder.FinishWithFileIdentifier(offset, metricListFileIdentifier)
+	builder.FinishWithFileIdentifier(offset, []byte("CIML"))
 	reader := bytes.NewReader(builder.FinishedBytes())
 
 	return sc.WriteRawContext(ctx, reader, true, datapoints, nodes...)

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/raw_test.go
+++ b/raw_test.go
@@ -15,12 +15,12 @@ func TestWriteRaw(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -32,18 +32,17 @@ func TestWriteRaw(t *testing.T) {
 
 			if string(b) == "test" {
 				w.WriteHeader(200)
-				w.Write([]byte(`{ "records": 0, "updated": 0, "misdirected": 0, "errors": 0 }`))
+				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, "misdirected": 0, "errors": 0 }`))
 				return
 			}
 
 			w.WriteHeader(500)
-			w.Write([]byte("invalid request body"))
+			_, _ = w.Write([]byte("invalid request body"))
 			return
 		}
 
 		t.Errorf("Unexpected request: %v", r)
 		w.WriteHeader(500)
-		return
 	}))
 
 	defer ms.Close()

--- a/rollup.go
+++ b/rollup.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -193,9 +194,8 @@ func (sc *SnowthClient) ReadRollupValues(uuid, metric string, period time.Durati
 
 // ReadRollupValuesContext is the context aware version of ReadRollupValues.
 func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
-	uuid, metric string, period time.Duration,
-	start, end time.Time, dataType string, nodes ...*SnowthNode) ([]RollupValue, error) {
-
+	uuid, metric string, period time.Duration, start, end time.Time,
+	dataType string, nodes ...*SnowthNode) ([]RollupValue, error) {
 	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
@@ -244,7 +244,6 @@ func (sc *SnowthClient) ReadRollupAllValues(
 func (sc *SnowthClient) ReadRollupAllValuesContext(ctx context.Context,
 	uuid, metric string, period time.Duration,
 	start, end time.Time, nodes ...*SnowthNode) ([]RollupAllValue, error) {
-
 	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -160,12 +160,12 @@ func TestReadRollupValues(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -173,7 +173,7 @@ func TestReadRollupValues(t *testing.T) {
 			"online?start_ts=1529509020&end_ts=1529509201&rollup_span=1s" +
 			"&type=average"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.Write([]byte(rollupTestData))
+			_, _ = w.Write([]byte(rollupTestData))
 			return
 		}
 	}))
@@ -214,12 +214,12 @@ func TestReadRollupAllValues(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -227,7 +227,7 @@ func TestReadRollupAllValues(t *testing.T) {
 			"online?start_ts=1529509020&end_ts=1529509201&rollup_span=1s" +
 			"&type=all"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.Write([]byte(rollupAllTestData))
+			_, _ = w.Write([]byte(rollupAllTestData))
 			return
 		}
 	}))

--- a/state.go
+++ b/state.go
@@ -101,7 +101,10 @@ func (r *Rollup) UnmarshalJSON(b []byte) error {
 		if strings.HasPrefix(k, "rollup_") {
 			b, _ := json.Marshal(v)
 			rd := new(RollupDetails)
-			json.Unmarshal(b, rd)
+			if err := json.Unmarshal(b, rd); err != nil {
+				return err
+			}
+
 			rr[k] = *rd
 		}
 	}
@@ -157,44 +160,29 @@ func (f *Features) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+loop:
 	for k, v := range m {
-		switch k {
-		case "text:store":
-			if v == "1" {
+		if v == "1" {
+			switch k {
+			case "text:store":
 				f.TextStore = true
-			}
-
-			break
-		case "histogram:store":
-			if v == "1" {
+				break loop
+			case "histogram:store":
 				f.HistogramStore = true
-			}
-
-			break
-		case "nnt:second_order":
-			if v == "1" {
+				break loop
+			case "nnt:second_order":
 				f.NNTSecondOrder = true
-			}
-
-			break
-		case "histogram:dynamic_rollups":
-			if v == "1" {
+				break loop
+			case "histogram:dynamic_rollups":
 				f.HistogramDynamicRollups = true
-			}
-
-			break
-		case "nnt:store":
-			if v == "1" {
+				break loop
+			case "nnt:store":
 				f.NNTStore = true
-			}
-
-			break
-		case "features":
-			if v == "1" {
+				break loop
+			case "features":
 				f.FeatureFlags = true
+				break loop
 			}
-
-			break
 		}
 	}
 

--- a/state.go
+++ b/state.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -16,7 +17,6 @@ func (sc *SnowthClient) GetNodeState(nodes ...*SnowthNode) (*NodeState, error) {
 // GetNodeStateContext is the context aware version of GetNodeState.
 func (sc *SnowthClient) GetNodeStateContext(ctx context.Context,
 	nodes ...*SnowthNode) (*NodeState, error) {
-
 	node := sc.GetActiveNode()
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]

--- a/state_test.go
+++ b/state_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/stats.go
+++ b/stats.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -14,7 +15,6 @@ func (sc *SnowthClient) GetStats(nodes ...*SnowthNode) (*Stats, error) {
 // GetStatsContext is the context aware version of GetStats.
 func (sc *SnowthClient) GetStatsContext(ctx context.Context,
 	nodes ...*SnowthNode) (*Stats, error) {
-
 	node := sc.GetActiveNode()
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]

--- a/stats_test.go
+++ b/stats_test.go
@@ -41,17 +41,17 @@ func TestGetStats(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 	}))

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/tags.go
+++ b/tags.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -185,8 +186,8 @@ func (ftl *FindTagsLatestHistogram) UnmarshalJSON(b []byte) error {
 }
 
 // FindTags retrieves metrics that are associated with the provided tag query.
-func (sc *SnowthClient) FindTags(accountID int64,
-	query string, options *FindTagsOptions, nodes ...*SnowthNode) (*FindTagsResult, error) {
+func (sc *SnowthClient) FindTags(accountID int64, query string,
+	options *FindTagsOptions, nodes ...*SnowthNode) (*FindTagsResult, error) {
 	return sc.FindTagsContext(context.Background(), accountID, query,
 		options, nodes...)
 }
@@ -195,7 +196,6 @@ func (sc *SnowthClient) FindTags(accountID int64,
 func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 	query string, options *FindTagsOptions,
 	nodes ...*SnowthNode) (*FindTagsResult, error) {
-
 	node := sc.GetActiveNode()
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/tags_test.go
+++ b/tags_test.go
@@ -94,18 +94,18 @@ func TestFindTags(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
 			w.Header().Set("X-Snowth-Search-Result-Count", "1")
-			w.Write([]byte(tagsTestData))
+			_, _ = w.Write([]byte(tagsTestData))
 			return
 		}
 	}))

--- a/text_test.go
+++ b/text_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -106,12 +107,12 @@ func TestWriteText(t *testing.T) {
 	}
 
 	node := &SnowthNode{url: u}
-	err = sc.WriteText(node, TextData{
+	err = sc.WriteText([]TextData{{
 		Metric: "test",
 		ID:     "3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d",
 		Offset: "1",
 		Value:  "test",
-	})
+	}}, node)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/text_test.go
+++ b/text_test.go
@@ -23,23 +23,22 @@ func TestReadTextValues(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI,
 			"/read/1/2/3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d/test") {
-			w.Write([]byte(textTestData))
+			_, _ = w.Write([]byte(textTestData))
 			return
 		}
 
 		w.WriteHeader(500)
-		return
 	}))
 
 	defer ms.Close()
@@ -77,12 +76,12 @@ func TestWriteText(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
@@ -93,7 +92,6 @@ func TestWriteText(t *testing.T) {
 		}
 
 		w.WriteHeader(500)
-		return
 	}))
 
 	defer ms.Close()

--- a/topology.go
+++ b/topology.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -22,12 +23,12 @@ type topologyNodeSlot struct {
 
 // Topology values represent IRONdb topology structure.
 type Topology struct {
-	XMLName        xml.Name       `xml:"nodes" json:"-"`
-	OldWriteCopies uint8          `xml:"n,attr" json:"-"`
-	WriteCopies    uint8          `xml:"write_copies,attr" json:"-"`
+	XMLName        xml.Name `xml:"nodes" json:"-"`
+	OldWriteCopies uint8    `xml:"n,attr" json:"-"`
+	WriteCopies    uint8    `xml:"write_copies,attr" json:"-"`
+	useSide        bool
 	Hash           string         `xml:"-"`
 	Nodes          []TopologyNode `xml:"node"`
-	useSide        bool
 	ring           []topologyNodeSlot
 }
 
@@ -238,7 +239,7 @@ func (topo *Topology) FindMetricNodeIDs(uuid, metric string) ([]string, error) {
 	nodes, err := topo.FindN(strings.ToLower(uuid)+"-"+metric, int(topo.WriteCopies))
 	if nodes == nil {
 		if err == nil {
-			err = errors.New("FindN failed")
+			err = errors.New("unable to find metric node: FindN failed")
 		}
 		return nil, err
 	}
@@ -267,7 +268,7 @@ func (topo *Topology) Find(s string) ([]TopologyNode, error) {
 // FindN finds n nodes on which s lives
 func (topo *Topology) FindN(s string, n int) ([]TopologyNode, error) {
 	if topo.ring == nil || len(topo.ring) < 1 {
-		return nil, errors.New("Empty topology")
+		return nil, errors.New("unable to find n nodes: empty topology")
 	}
 	location := sha256.Sum256([]byte(s))
 	nodes := make([]TopologyNode, 0)

--- a/topology_test.go
+++ b/topology_test.go
@@ -167,7 +167,8 @@ func BenchmarkLookup1(b *testing.B) {
 	}
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		topo.FindMetric(id, "this.is.a.metric|ST[nice:andhappy,with:tags]")
+		_, _ = topo.FindMetric(id,
+			"this.is.a.metric|ST[nice:andhappy,with:tags]")
 	}
 }
 func TestLiveNode(t *testing.T) {
@@ -195,18 +196,18 @@ func TestTopology(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
 		r *http.Request) {
 		if r.RequestURI == "/state" {
-			w.Write([]byte(stateTestData))
+			_, _ = w.Write([]byte(stateTestData))
 			return
 		}
 
 		if r.RequestURI == "/stats.json" {
-			w.Write([]byte(statsTestData))
+			_, _ = w.Write([]byte(statsTestData))
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI,
 			"/topology/xml") {
-			w.Write([]byte(topologyXMLTestData))
+			_, _ = w.Write([]byte(topologyXMLTestData))
 			return
 		}
 
@@ -223,7 +224,6 @@ func TestTopology(t *testing.T) {
 		}
 
 		w.WriteHeader(500)
-		return
 	}))
 
 	defer ms.Close()

--- a/topology_test.go
+++ b/topology_test.go
@@ -1,3 +1,4 @@
+// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (
@@ -96,28 +97,28 @@ func TestTopologyXMLSerialization(t *testing.T) {
 	topo := Topology{
 		WriteCopies: 2,
 		Nodes: []TopologyNode{
-			TopologyNode{
+			{
 				ID:      "1f846f26-0cfd-4df5-b4f1-e0930604e577",
 				Address: "10.8.20.1",
 				Port:    8112,
 				APIPort: 8112,
 				Weight:  32,
 			},
-			TopologyNode{
+			{
 				ID:      "765ac4cc-1929-4642-9ef1-d194d08f9538",
 				Address: "10.8.20.2",
 				Port:    8112,
 				APIPort: 8112,
 				Weight:  32,
 			},
-			TopologyNode{
+			{
 				ID:      "8c2fc7b8-c569-402d-a393-db433fb267aa",
 				Address: "10.8.20.3",
 				Port:    8112,
 				APIPort: 8112,
 				Weight:  32,
 			},
-			TopologyNode{
+			{
 				ID:      "07fa2237-5744-4c28-a622-a99cfc1ac87e",
 				Address: "10.8.20.4",
 				Port:    8112,


### PR DESCRIPTION
- A number of minor cleanups and fixes to allow this package to pass almost all linters in golangci-lint.
- Adds linting configuration to the repo.
- Expands the new node-optional API interface to some additional functions.