### PR TITLE
CIRC-5002: Implement option to retry on network errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,9 +6,15 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
-* Adds an option, off by default, but can be set with SnowthClient.SetRetries(),
-that allows the client to retry requests to IRONdb that fail due to network
-errors on other available nodes, a specified number of times.
+* Adds an option, not used by default, to retry requests to IRONdb that fail
+for reasons that might be resolved by retrying. The number of attempts can be
+set using the SnowthClient.SetRetries() method. Delay will increase between
+each successive retry attempt.
+* Adds an option, off by default, but can be set with
+SnowthClient.SetConnectRetries(), that allows the client to retry requests 
+to IRONdb that fail due to network errors on other available nodes, up to a 
+specified number of times. This can be used in conjuction with
+SnowthClient.SetRetries() or on its own.
 * Added a `Limit` field to `FindTagsOptions` struct for specifying the maximum
 number of metric results returned from the IRONdb find call.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+* Adds an option, off by default, but can be set with SnowthClient.SetRetries(),
+that allows the client to retry requests to IRONdb that fail due to network
+errors on other available nodes, a specified number of times.
 * Added a `Limit` field to `FindTagsOptions` struct for specifying the maximum
 number of metric results returned from the IRONdb find call.
 

--- a/activity.go
+++ b/activity.go
@@ -28,7 +28,7 @@ func (sc *SnowthClient) RebuildActivityContext(ctx context.Context,
 		return nil, err
 	}
 
-	body, _, err := sc.do(ctx, node, "POST", "/surrogate/activity_rebuild", data, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "POST", "/surrogate/activity_rebuild", data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/caql.go
+++ b/caql.go
@@ -92,9 +92,11 @@ func (sc *SnowthClient) GetCAQLQuery(q *CAQLQuery,
 // GetCAQLQueryContext is the context aware version of GetCAQLQuery.
 func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 	nodes ...*SnowthNode) (*DF4Response, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
 
 	if q == nil {
@@ -119,7 +121,7 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 	}
 
 	r := &DF4Response{}
-	body, _, err := sc.do(ctx, node, "POST", u, bytes.NewBuffer(bBuf), nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "POST", u, bytes.NewBuffer(bBuf), nil)
 	if err != nil {
 		if body != nil {
 			cErr := &CAQLError{}

--- a/client.go
+++ b/client.go
@@ -764,10 +764,9 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 				return bdy, hdr, err
 			}
 
-			// This is a pretty crude way to detect networking errors.
-			// But, it does work. Any broken network errors will contain
-			// 'dial tcp:' and will be from the http.Client.
-			if !strings.Contains(err.Error(), "dial tcp:") {
+			// Stop retrying other nodes if this is not a network connection
+			// error.
+			if nerr, ok := err.(net.Error); ok && !nerr.Temporary() {
 				break
 			}
 

--- a/client.go
+++ b/client.go
@@ -186,6 +186,8 @@ func NewClient(cfg *Config) (*SnowthClient, error) {
 		activeNodes:   []*SnowthNode{},
 		inactiveNodes: []*SnowthNode{},
 		watchInterval: cfg.WatchInterval(),
+		retries:       cfg.Retries(),
+		connRetries:   cfg.ConnectRetries(),
 		dumpRequests:  os.Getenv("GOSNOWTH_DUMP_REQUESTS"),
 		traceRequests: os.Getenv("GOSNOWTH_TRACE_REQUESTS"),
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -75,12 +75,13 @@ func TestSnowthClientRequest(t *testing.T) {
 		t.Fatal("Unable to create snowth client", err)
 	}
 
+	sc.SetRetries(1)
 	sc.SetRequestFunc(func(r *http.Request) error {
 		r.Header.Set("X-Test-Header", "test")
 		return nil
 	})
 
-	u, err := url.Parse(ms.URL)
+	u, err := url.Parse("http://invalid")
 	if err != nil {
 		t.Fatal("Invalid test URL")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -76,6 +76,7 @@ func TestSnowthClientRequest(t *testing.T) {
 	}
 
 	sc.SetRetries(1)
+	sc.SetConnectRetries(1)
 	sc.SetRequestFunc(func(r *http.Request) error {
 		r.Header.Set("X-Test-Header", "test")
 		return nil

--- a/common.go
+++ b/common.go
@@ -82,6 +82,10 @@ func encodeJSON(v interface{}) (io.Reader, error) {
 
 // decodeJSON decodes JSON from a reader into an interface.
 func decodeJSON(r io.Reader, v interface{}) error {
+	if r == nil {
+		return errors.New("unable to decode from nil reader")
+	}
+
 	if err := json.NewDecoder(r).Decode(v); err != nil {
 		return errors.Wrap(err, "failed to decode JSON")
 	}

--- a/config.go
+++ b/config.go
@@ -25,11 +25,13 @@ type Config struct {
 // NewConfig creates and initializes a new SnowthClient configuration value.
 func NewConfig(servers ...string) (*Config, error) {
 	c := &Config{
-		dialTimeout:   500 * time.Millisecond,
-		discover:      false,
-		servers:       []string{},
-		timeout:       10 * time.Second,
-		watchInterval: 30 * time.Second,
+		dialTimeout:    500 * time.Millisecond,
+		discover:       false,
+		servers:        []string{},
+		timeout:        10 * time.Second,
+		watchInterval:  30 * time.Second,
+		retries:        0,
+		connectRetries: -1,
 	}
 
 	if err := c.SetServers(servers...); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -31,6 +31,8 @@ func TestNewConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cfg.SetRetries(1)
+	cfg.SetConnectRetries(1)
 	if err := cfg.SetWatchInterval(time.Second); err != nil {
 		t.Fatal(err)
 	}
@@ -63,6 +65,14 @@ func TestNewConfig(t *testing.T) {
 	if cfg.Timeout() != time.Second {
 		t.Errorf("Expected timeout: %v, got: %v",
 			time.Second, cfg.Timeout())
+	}
+
+	if cfg.Retries() != 1 {
+		t.Errorf("Expected retries: 1, got: %v", cfg.Retries())
+	}
+
+	if cfg.ConnectRetries() != 1 {
+		t.Errorf("Expected connect retries: 1, got: %v", cfg.ConnectRetries())
 	}
 
 	if cfg.WatchInterval() != time.Second {

--- a/fetch.go
+++ b/fetch.go
@@ -136,11 +136,12 @@ func (sc *SnowthClient) FetchValues(q *FetchQuery, nodes ...*SnowthNode) (*DF4Re
 func (sc *SnowthClient) FetchValuesContext(ctx context.Context,
 	q *FetchQuery, nodes ...*SnowthNode) (*DF4Response, error) {
 	var node *SnowthNode
-	if len(nodes) > 0 && nodes[0] != nil {
+	switch {
+	case len(nodes) > 0 && nodes[0] != nil:
 		node = nodes[0]
-	} else if len(q.Streams) > 0 {
+	case len(q.Streams) > 0:
 		node = sc.GetActiveNode(sc.FindMetricNodeIDs(q.Streams[0].UUID, q.Streams[0].Name))
-	} else {
+	default:
 		node = sc.GetActiveNode()
 	}
 

--- a/fetch.go
+++ b/fetch.go
@@ -136,21 +136,21 @@ func (sc *SnowthClient) FetchValues(q *FetchQuery, nodes ...*SnowthNode) (*DF4Re
 func (sc *SnowthClient) FetchValuesContext(ctx context.Context,
 	q *FetchQuery, nodes ...*SnowthNode) (*DF4Response, error) {
 	var node *SnowthNode
-	if len(q.Streams) > 0 {
+	if len(nodes) > 0 && nodes[0] != nil {
+		node = nodes[0]
+	} else if len(q.Streams) > 0 {
 		node = sc.GetActiveNode(sc.FindMetricNodeIDs(q.Streams[0].UUID, q.Streams[0].Name))
 	} else {
 		node = sc.GetActiveNode()
 	}
-	if len(nodes) > 0 && nodes[0] != nil {
-		node = nodes[0]
-	}
+
 	buf := &bytes.Buffer{}
 	if err := json.NewEncoder(buf).Encode(&q); err != nil {
 		return nil, err
 	}
 
 	hdrs := http.Header{"Content-Type": {"application/json"}}
-	body, _, err := sc.do(ctx, node, "POST", "/fetch", buf, hdrs)
+	body, _, err := sc.DoRequestContext(ctx, node, "POST", "/fetch", buf, hdrs)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (sc *SnowthClient) FetchValuesFbContext(ctx context.Context,
 		"Content-Type": {FetchFlatbufferContentType},
 		"Accept":       {Df4FlatbufferAccept},
 	}
-	body, _, err := sc.do(ctx, node, "POST", "/fetch", buf, hdrs)
+	body, _, err := sc.DoRequestContext(ctx, node, "POST", "/fetch", buf, hdrs)
 	if err != nil {
 		return nil, err
 	}

--- a/gossip.go
+++ b/gossip.go
@@ -38,12 +38,15 @@ func (sc *SnowthClient) GetGossipInfo(
 // GetGossipInfoContext is the context aware version of GetGossipInfo.
 func (sc *SnowthClient) GetGossipInfoContext(ctx context.Context,
 	nodes ...*SnowthNode) (*Gossip, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	r := &Gossip{}
-	body, _, err := sc.do(ctx, node, "GET", "/gossip/json", nil, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", "/gossip/json", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/location.go
+++ b/location.go
@@ -51,7 +51,7 @@ func (sc *SnowthClient) LocateMetricRemoteContext(ctx context.Context, uuid stri
 		}
 		node = nodes[0]
 	}
-	body, _, err := sc.do(ctx, node, "GET",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET",
 		path.Join("/locate/xml", uuid, metric), nil, nil)
 	if err != nil {
 		return nil, err

--- a/lua.go
+++ b/lua.go
@@ -132,13 +132,16 @@ func (sc *SnowthClient) GetLuaExtensions(nodes ...*SnowthNode) (LuaExtensions,
 // GetLuaExtensionsContext is the context aware version of GetLuaExtensions.
 func (sc *SnowthClient) GetLuaExtensionsContext(ctx context.Context,
 	nodes ...*SnowthNode) (LuaExtensions, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	u := sc.getURL(node, "/extension/lua")
 	r := LuaExtensions{}
-	body, _, err := sc.do(ctx, node, "GET", u, nil, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", u, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,10 +171,13 @@ func (sc *SnowthClient) ExecLuaExtension(name string,
 func (sc *SnowthClient) ExecLuaExtensionContext(ctx context.Context,
 	name string, params []ExtParam,
 	nodes ...*SnowthNode) (map[string]interface{}, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	u := sc.getURL(node, "/extension/lua/"+name)
 	if len(params) > 0 {
 		qp := url.Values{}
@@ -183,7 +189,7 @@ func (sc *SnowthClient) ExecLuaExtensionContext(ctx context.Context,
 	}
 
 	r := map[string]interface{}{}
-	body, _, err := sc.do(ctx, node, "GET", u, nil, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", u, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nnt.go
+++ b/nnt.go
@@ -162,7 +162,7 @@ func (sc *SnowthClient) WriteNNTContext(ctx context.Context,
 			data[0].Metric))
 	}
 
-	_, _, err := sc.do(ctx, node, "POST", "/write/nnt", buf, nil)
+	_, _, err := sc.DoRequestContext(ctx, node, "POST", "/write/nnt", buf, nil)
 	return err
 }
 
@@ -185,7 +185,7 @@ func (sc *SnowthClient) ReadNNTValuesContext(ctx context.Context,
 	}
 
 	r := &NNTValueResponse{}
-	body, _, err := sc.do(ctx, node, "GET", path.Join("/read",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", path.Join("/read",
 		strconv.FormatInt(start.Unix(), 10),
 		strconv.FormatInt(end.Unix(), 10),
 		strconv.FormatInt(period, 10), id, t, metric), nil, nil)
@@ -219,7 +219,7 @@ func (sc *SnowthClient) ReadNNTAllValuesContext(ctx context.Context,
 	}
 
 	r := &NNTAllValueResponse{}
-	body, _, err := sc.do(ctx, node, "GET", path.Join("/read",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", path.Join("/read",
 		strconv.FormatInt(start.Unix(), 10),
 		strconv.FormatInt(end.Unix(), 10),
 		strconv.FormatInt(period, 10), id, "all", metric), nil, nil)

--- a/rollup.go
+++ b/rollup.go
@@ -196,9 +196,11 @@ func (sc *SnowthClient) ReadRollupValues(uuid, metric string, period time.Durati
 func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
 	uuid, metric string, period time.Duration, start, end time.Time,
 	dataType string, nodes ...*SnowthNode) ([]RollupValue, error) {
-	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	}
 
 	if dataType == "" {
@@ -217,7 +219,7 @@ func (sc *SnowthClient) ReadRollupValuesContext(ctx context.Context,
 	endTS := end.Unix() - end.Unix()%int64(period/time.Second) +
 		int64(period/time.Second)
 	r := []RollupValue{}
-	body, _, err := sc.do(ctx, node, "GET",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET",
 		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds&type=%s",
 			path.Join("/rollup", uuid, url.QueryEscape(metric)),
 			startTS, endTS, int64(period/time.Second), dataType), nil, nil)
@@ -244,16 +246,18 @@ func (sc *SnowthClient) ReadRollupAllValues(
 func (sc *SnowthClient) ReadRollupAllValuesContext(ctx context.Context,
 	uuid, metric string, period time.Duration,
 	start, end time.Time, nodes ...*SnowthNode) ([]RollupAllValue, error) {
-	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	}
 
 	startTS := start.Unix() - start.Unix()%int64(period/time.Second)
 	endTS := end.Unix() - end.Unix()%int64(period/time.Second) +
 		int64(period/time.Second)
 	r := []RollupAllValue{}
-	body, _, err := sc.do(ctx, node, "GET",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET",
 		fmt.Sprintf("%s?start_ts=%d&end_ts=%d&rollup_span=%ds&type=all",
 			path.Join("/rollup", uuid, url.QueryEscape(metric)),
 			startTS, endTS, int64(period/time.Second)), nil, nil)

--- a/state.go
+++ b/state.go
@@ -17,13 +17,15 @@ func (sc *SnowthClient) GetNodeState(nodes ...*SnowthNode) (*NodeState, error) {
 // GetNodeStateContext is the context aware version of GetNodeState.
 func (sc *SnowthClient) GetNodeStateContext(ctx context.Context,
 	nodes ...*SnowthNode) (*NodeState, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
 
 	r := &NodeState{}
-	body, _, err := sc.do(ctx, node, "GET", "/state", nil, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", "/state", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/stats.go
+++ b/stats.go
@@ -15,13 +15,15 @@ func (sc *SnowthClient) GetStats(nodes ...*SnowthNode) (*Stats, error) {
 // GetStatsContext is the context aware version of GetStats.
 func (sc *SnowthClient) GetStatsContext(ctx context.Context,
 	nodes ...*SnowthNode) (*Stats, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
 
 	r := &Stats{}
-	body, _, err := sc.do(ctx, node, "GET", "/stats.json", nil, nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", "/stats.json", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tags.go
+++ b/tags.go
@@ -198,9 +198,11 @@ func (sc *SnowthClient) FindTags(accountID int64, query string,
 func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 	query string, options *FindTagsOptions,
 	nodes ...*SnowthNode) (*FindTagsResult, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
 
 	u := fmt.Sprintf("%s?query=%s",
@@ -222,8 +224,9 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 	if options.Limit != 0 {
 		hdrs.Set("X-Snowth-Advisory-Limit", strconv.FormatInt(options.Limit, 10))
 	}
+
 	r := &FindTagsResult{}
-	body, header, err := sc.do(ctx, node, "GET", u, nil, hdrs)
+	body, header, err := sc.DoRequestContext(ctx, node, "GET", u, nil, hdrs)
 	if err != nil {
 		return nil, err
 	}

--- a/tags_test.go
+++ b/tags_test.go
@@ -129,7 +129,7 @@ func TestFindTags(t *testing.T) {
 		Activity:  1,
 		Latest:    1,
 		CountOnly: 0,
-		Limit:    -1,
+		Limit:     -1,
 	}, node)
 	if err != nil {
 		t.Fatal(err)

--- a/text.go
+++ b/text.go
@@ -57,13 +57,15 @@ func (sc *SnowthClient) ReadTextValues(uuid, metric string,
 func (sc *SnowthClient) ReadTextValuesContext(ctx context.Context,
 	uuid, metric string, start, end time.Time,
 	nodes ...*SnowthNode) ([]TextValue, error) {
-	node := sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode(sc.FindMetricNodeIDs(uuid, metric))
 	}
 
 	r := TextValueResponse{}
-	body, _, err := sc.do(ctx, node, "GET", path.Join("/read",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET", path.Join("/read",
 		strconv.FormatInt(start.Unix(), 10),
 		strconv.FormatInt(end.Unix(), 10), uuid, metric), nil, nil)
 	if err != nil {
@@ -106,6 +108,6 @@ func (sc *SnowthClient) WriteTextContext(ctx context.Context,
 		return errors.Wrap(err, "failed to encode TextData for write")
 	}
 
-	_, _, err := sc.do(ctx, node, "POST", "/write/text", buf, nil)
+	_, _, err := sc.DoRequestContext(ctx, node, "POST", "/write/text", buf, nil)
 	return err
 }

--- a/topology.go
+++ b/topology.go
@@ -285,10 +285,13 @@ func (topo *Topology) FindN(s string, n int) ([]TopologyNode, error) {
 
 // GetTopologyInfo retrieves topology information from a node.
 func (sc *SnowthClient) GetTopologyInfo(nodes ...*SnowthNode) (*Topology, error) {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	if node == nil {
 		return nil, errors.New("no active nodes")
 	}
@@ -312,10 +315,13 @@ func TopologyLoadXML(xml string) (*Topology, error) {
 func (sc *SnowthClient) GetTopologyInfoContext(ctx context.Context,
 	nodes ...*SnowthNode) (*Topology, error) {
 	r := &Topology{}
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	topologyID := node.GetCurrentTopology()
 	if topologyID == "" {
 		return nil, errors.New("no active topology")
@@ -323,7 +329,7 @@ func (sc *SnowthClient) GetTopologyInfoContext(ctx context.Context,
 	if topologyID == sc.currentTopology && sc.currentTopologyCompiled != nil {
 		return sc.currentTopologyCompiled, nil
 	}
-	body, _, err := sc.do(ctx, node, "GET",
+	body, _, err := sc.DoRequestContext(ctx, node, "GET",
 		path.Join("/topology/xml", node.GetCurrentTopology()), nil, nil)
 	if err != nil {
 		return nil, err
@@ -344,10 +350,13 @@ func (sc *SnowthClient) GetTopologyInfoContext(ctx context.Context,
 // LoadTopology loads a new topology on a node without activating it.
 func (sc *SnowthClient) LoadTopology(hash string, t *Topology,
 	nodes ...*SnowthNode) error {
-	node := sc.GetActiveNode()
+	var node *SnowthNode
 	if len(nodes) > 0 && nodes[0] != nil {
 		node = nodes[0]
+	} else {
+		node = sc.GetActiveNode()
 	}
+
 	return sc.LoadTopologyContext(context.Background(), hash, t, node)
 }
 
@@ -359,7 +368,7 @@ func (sc *SnowthClient) LoadTopologyContext(ctx context.Context, hash string,
 		return errors.Wrap(err, "failed to encode request data")
 	}
 
-	_, _, err = sc.do(ctx, node, "POST", path.Join("/topology", hash), b, nil)
+	_, _, err = sc.DoRequestContext(ctx, node, "POST", path.Join("/topology", hash), b, nil)
 	return err
 }
 
@@ -373,6 +382,6 @@ func (sc *SnowthClient) ActivateTopology(hash string, node *SnowthNode) error {
 // WARNING THIS IS DANGEROUS.
 func (sc *SnowthClient) ActivateTopologyContext(ctx context.Context,
 	hash string, node *SnowthNode) error {
-	_, _, err := sc.do(ctx, node, "GET", path.Join("/activate", hash), nil, nil)
+	_, _, err := sc.DoRequestContext(ctx, node, "GET", path.Join("/activate", hash), nil, nil)
 	return err
 }


### PR DESCRIPTION
-  Adds an option, which is off by default, but can be set with SnowthClient.SetRetries(), that allows the client to retry requests to IRONdb that fail due to network errors on other available nodes, a specified number of times, or until there are no more know nodes to try.
- Changes all functions to only lookup which node to call if a specific node is not provided to the function.