### PR TITLE
CIRC-5002: Fix retry POST request bug and improve debug logs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.5.2] - 2020-05-01
+
+* Adds additional debug logging, if configured, to support better tracking of
+IRONdb request retries.
+* Fixes a bug that would cause failures on POST requests to IRONdb if the
+request needed to be retried on more than one node.
+
 ## [v1.5.1] - 2020-04-30
 
 * Adds an option, not used by default, to retry requests to IRONdb that fail
@@ -240,6 +247,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.5.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.2
 [v1.5.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.1
 [v1.5.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.0
 [v1.4.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.4.6

--- a/caql_test.go
+++ b/caql_test.go
@@ -59,6 +59,12 @@ func TestGetCAQLQuery(t *testing.T) {
 				return
 			}
 
+			if len(b) == 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(testCAQLError))
+				return
+			}
+
 			if strings.Contains(string(b), "histograms") {
 				w.WriteHeader(502)
 				_, _ = w.Write([]byte(testCAQLError))
@@ -76,7 +82,9 @@ func TestGetCAQLQuery(t *testing.T) {
 		t.Fatal("Unable to create snowth client", err)
 	}
 
-	u, err := url.Parse(ms.URL)
+	sc.SetRetries(1)
+	sc.SetConnectRetries(1)
+	u, err := url.Parse("http://invalid")
 	if err != nil {
 		t.Fatal("Invalid test URL")
 	}

--- a/client.go
+++ b/client.go
@@ -896,7 +896,7 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 		fmt.Println(string(dump))
 	}
 
-	sc.LogDebugf("snowth request: %+v", r)
+	sc.LogDebugf("gosnowth request: %+v", r)
 	var start = time.Now()
 	sc.RLock()
 	cli := sc.c
@@ -932,9 +932,9 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 		fmt.Printf("TRACE-%d: complete %s - %s\n", traceID, resp.Status, msg)
 	}
 
-	sc.LogDebugf("snowth response: %+v", resp)
-	sc.LogDebugf("snowth response body: %v", string(res))
-	sc.LogDebugf("snowth latency: %+v", time.Since(start))
+	sc.LogDebugf("gosnowth response: %+v", resp)
+	// sc.LogDebugf("gosnowth response body: %v", string(res))
+	sc.LogDebugf("gosnowth latency: %+v", time.Since(start))
 	select {
 	case <-ctx.Done():
 		return nil, nil, errors.Wrap(ctx.Err(), "context terminated")

--- a/client.go
+++ b/client.go
@@ -730,9 +730,6 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 		retries = 0
 	}
 
-	sc.RLock()
-	log := sc.log
-	sc.RUnlock()
 	bBody := []byte{}
 	var err error
 	if body != nil {
@@ -765,16 +762,16 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 				surl = sc.getURL(sn, u)
 			}
 
-			if log != nil {
-				log.Debugf("gosnowth attempting request: %s %s %v",
-					method, surl, sn)
-			}
-
+			sc.LogDebugf("gosnowth attempting request: %s %s %v",
+				method, surl, sn)
 			bdy, hdr, err = sc.do(ctx, sn, method, surl,
 				bytes.NewBuffer(bBody), headers)
 			if err == nil {
 				return bdy, hdr, nil
 			}
+
+			sc.LogDebugf("gosnowth request error: %s %s %v",
+				method, surl, err)
 
 			// There are likely more types of IRONdb errors that need to be
 			// checked for and included in this section for errors which

--- a/config_test.go
+++ b/config_test.go
@@ -83,7 +83,8 @@ func TestNewConfig(t *testing.T) {
 
 func TestConfigMarshalJSON(t *testing.T) {
 	s := `{"dial_timeout":"100ms","discover":true,"timeout":"1s",` +
-		`"watch_interval":"5s","servers":["localhost:8112"]}`
+		`"watch_interval":"5s","connect_retries":-1,` +
+		`"servers":["localhost:8112"]}`
 	c, err := NewConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -152,11 +153,30 @@ func TestConfigMarshalJSON(t *testing.T) {
 	}
 
 	s = `{"dial_timeout":"100ms","discover":true,` +
-		`"servers":[":invalid"],"timeout":"10s","watch_interval":"30s"}`
+		`"connect_retries":-1,"servers":[":invalid"],"timeout":"10s",` +
+		`"watch_interval":"30s"}`
 	err = json.Unmarshal([]byte(s), c)
 	if err == nil || !strings.Contains(err.Error(),
 		"invalid server address") {
 		t.Error("Expected error not returned.")
+	}
+
+	s = `{"dial_timeout":"100ms","discover":true,"retries":"invalid",` +
+		`"connect_retries":"invalid","servers":[":invalid"],"timeout":"10s",` +
+		`"watch_interval":"30s"}`
+	err = json.Unmarshal([]byte(s), c)
+	if err == nil || !strings.Contains(err.Error(),
+		"unmarshal string into Go struct field .retries of type") {
+		t.Errorf("Expected error not returned, got: %v", err)
+	}
+
+	s = `{"dial_timeout":"100ms","discover":true,` +
+		`"connect_retries":"invalid","servers":[":invalid"],"timeout":"10s",` +
+		`"watch_interval":"30s"}`
+	err = json.Unmarshal([]byte(s), c)
+	if err == nil || !strings.Contains(err.Error(),
+		"unmarshal string into Go struct field .connect_retries of type") {
+		t.Errorf("Expected error not returned, got: %v", err)
 	}
 
 	s = `{$$$}`


### PR DESCRIPTION
* Adds additional debug logging, if configured, to support better tracking of IRONdb request retries.
* Fixes a bug that would cause failures on POST requests to IRONdb if the request needed to be retried on more than one node.