### PR TITLE
CIRC-5228: Allow infinity and NaN DF4 data values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+* Supports DF4 responses that contain data values of [+/-]inf or NaN.
+
 ## [v1.5.3] - 2020-05-07
 
 * Fixes an issue with node deactivation upon retry and adds the node discovery

--- a/caql.go
+++ b/caql.go
@@ -133,7 +133,14 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 		return nil, err
 	}
 
-	if err := decodeJSON(body, &r); err != nil {
+	rb, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read IRONdb response body")
+	}
+
+	rb = ReplaceInf(rb)
+
+	if err := decodeJSON(bytes.NewBuffer(rb), &r); err != nil {
 		return nil, errors.Wrap(err, "unable to decode IRONdb response")
 	}
 

--- a/caql_test.go
+++ b/caql_test.go
@@ -71,7 +71,7 @@ func TestGetCAQLQuery(t *testing.T) {
 				return
 			}
 
-			_, _ = w.Write([]byte(testDF4Response))
+			_, _ = w.Write([]byte(testFetchDF4Response))
 			return
 		}
 	}))

--- a/df4.go
+++ b/df4.go
@@ -1,7 +1,12 @@
 // Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"strconv"
+)
 
 // DF4Response values represent time series data in the DF4 format.
 type DF4Response struct {
@@ -51,4 +56,35 @@ func (dr *DF4Response) Copy() *DF4Response {
 	}
 
 	return b
+}
+
+// ReplaceInf is used to remove infinity and NaN values from DF4 JSON strings
+// prior to attempting to parse them into DF4Response values.
+func ReplaceInf(b []byte) []byte {
+	v := make([]byte, len(b))
+	copy(v, b)
+
+	v = bytes.Replace(v, []byte("+inf,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("+inf]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("-inf,"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("-inf]"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("inf,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("inf]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+
+	v = bytes.Replace(v, []byte("NaN,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("NaN]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("nan,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+	v = bytes.Replace(v, []byte("nan]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+
+	return v
 }

--- a/fetch.go
+++ b/fetch.go
@@ -156,8 +156,15 @@ func (sc *SnowthClient) FetchValuesContext(ctx context.Context,
 		return nil, err
 	}
 
+	rb, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read IRONdb response body")
+	}
+
+	rb = ReplaceInf(rb)
+
 	r := &DF4Response{}
-	if err := decodeJSON(body, &r); err != nil {
+	if err := decodeJSON(bytes.NewBuffer(rb), &r); err != nil {
 		return nil, errors.Wrap(err, "unable to decode IRONdb response")
 	}
 

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -28,6 +28,37 @@ const fetchTestQuery = `{
 	"reduce": [{"label":"test","method":"test"}]
 }`
 
+const testFetchDF4Response = `{
+	"version": "DF4",
+	"head": {
+		"count": 3,
+		"start": 0,
+		"period": 300,
+		"explain":{
+			"info":{
+				"putype":["none","number"]
+			}
+		}
+	},
+	"meta": [
+		{
+			"kind": "numeric",
+			"label": "test",
+			"tags": [
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test"
+			]
+		}
+	],
+	"data": [
+		[
+			1,
+			inf,
+			3
+		]
+	]
+}`
+
 func TestFetchQueryMarshaling(t *testing.T) {
 	v := &FetchQuery{}
 	err := json.NewDecoder(bytes.NewBufferString(fetchTestQuery)).Decode(&v)
@@ -67,7 +98,7 @@ func TestFetchQuery(t *testing.T) {
 
 		if strings.HasPrefix(r.RequestURI,
 			"/fetch") {
-			_, _ = w.Write([]byte(testDF4Response))
+			_, _ = w.Write([]byte(testFetchDF4Response))
 			return
 		}
 	}))


### PR DESCRIPTION
- It is possible for DF4 JSON responses from IRONdb to contain data values of `inf` and also possibly `NaN`.
- These values need to be removed prior to passing any data to the Go standard library JSON parser, or parsing will fail.
- These values have to be replaced in the raw []byte data, as the error they induce happens before any custom UnmarshalJSON code is called.