### PR TITLE
CIRC-6053: Fix DF4 inf value handling bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.5.6] - 2020-12-17
+
+* Fixes a bug causing gosnowth to sometimes return an error when encountering
++/-inf values in DF4 data responses from IRONdb.
 * Improves the LocateMetric unit tests to include testing the FindMetric
 node hashing logic.
 
@@ -266,6 +270,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.5.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.6
 [v1.5.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.5
 [v1.5.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.4
 [v1.5.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.3

--- a/df4.go
+++ b/df4.go
@@ -67,24 +67,34 @@ func ReplaceInf(b []byte) []byte {
 	v = bytes.Replace(v, []byte("+inf,"), []byte(
 		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
 	v = bytes.Replace(v, []byte("+inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
+	v = bytes.Replace(v, []byte("+inf\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
 	v = bytes.Replace(v, []byte("-inf,"), []byte(
 		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","), -1)
 	v = bytes.Replace(v, []byte("-inf]"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","), -1)
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"]"), -1)
+	v = bytes.Replace(v, []byte("-inf\n"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
 	v = bytes.Replace(v, []byte("inf,"), []byte(
 		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
 	v = bytes.Replace(v, []byte("inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
+	v = bytes.Replace(v, []byte("inf\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
 
 	v = bytes.Replace(v, []byte("NaN,"), []byte(
 		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
 	v = bytes.Replace(v, []byte("NaN]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
+	v = bytes.Replace(v, []byte("NaN\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
 	v = bytes.Replace(v, []byte("nan,"), []byte(
 		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
 	v = bytes.Replace(v, []byte("nan]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
+	v = bytes.Replace(v, []byte("nan\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
 
 	return v
 }

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -54,7 +54,9 @@ const testFetchDF4Response = `{
 		[
 			1,
 			inf,
-			3
+			3,
+			NaN,
+			-inf
 		]
 	]
 }`


### PR DESCRIPTION
* Fixes a bug affecting how gosnowth handles +inf, -inf, and NaN values if they are contained in the DF4 JSON response from IRONdb for fetch calls. When these values are the last in a set of data, gosnowth will no longer fail with a failed to decode JSON error.