### PR TITLE
CIRC-6072: Allow gosnowth to handle _count_only FindTags requests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.6.1] - 2020-12-23
+
+* upd: Added support for `_count_only` requests using the FindTags functions.
+
 ## [v1.5.6] - 2020-12-17
 
 * Fixes a bug causing gosnowth to sometimes return an error when encountering
@@ -270,6 +274,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.6.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.6.1
 [v1.5.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.6
 [v1.5.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.5
 [v1.5.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.5.4

--- a/tags.go
+++ b/tags.go
@@ -26,8 +26,15 @@ type FindTagsItem struct {
 
 // FindTagsResult values contain the results of a find tags request.
 type FindTagsResult struct {
-	Items []FindTagsItem
-	Count int64
+	Items     []FindTagsItem
+	FindCount FindTagsCount
+	Count     int64
+}
+
+// FindTagsCount values represent results from count only requests.
+type FindTagsCount struct {
+	Count    int64 `json:"count"`
+	Estimate bool  `json:"estimate"`
 }
 
 // FindTagsOptions values contain optional parameters to be passed to the
@@ -229,8 +236,14 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 		return nil, err
 	}
 
-	if err := decodeJSON(body, &r.Items); err != nil {
-		return nil, errors.Wrap(err, "unable to decode IRONdb response")
+	if options.CountOnly != 0 {
+		if err := decodeJSON(body, &r.FindCount); err != nil {
+			return nil, errors.Wrap(err, "unable to decode IRONdb response")
+		}
+	} else {
+		if err := decodeJSON(body, &r.Items); err != nil {
+			return nil, errors.Wrap(err, "unable to decode IRONdb response")
+		}
 	}
 
 	// Return a results count and capture it from the header , if provided.

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const tagsCountTestData = `{"count":22,"estimate":false}`
+
 const tagsTestData = `[
 	{
 		"uuid": "3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d",
@@ -100,6 +102,12 @@ func TestFindTags(t *testing.T) {
 			return
 		}
 
+		if strings.Contains(r.RequestURI, "&count_only=1") {
+			w.Header().Set("X-Snowth-Search-Result-Count", "1")
+			_, _ = w.Write([]byte(tagsCountTestData))
+			return
+		}
+
 		if strings.HasPrefix(r.RequestURI, "/find/1/tags?query=test") {
 			w.Header().Set("X-Snowth-Search-Result-Count", "1")
 			_, _ = w.Write([]byte(tagsTestData))
@@ -120,6 +128,22 @@ func TestFindTags(t *testing.T) {
 
 	node := &SnowthNode{url: u}
 	res, err := sc.FindTags(1, "test", &FindTagsOptions{
+		Start:     time.Unix(1, 0),
+		End:       time.Unix(2, 0),
+		Activity:  0,
+		Latest:    0,
+		CountOnly: 1,
+		Limit:     -1,
+	}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Count != 1 {
+		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+	}
+
+	res, err = sc.FindTags(1, "test", &FindTagsOptions{
 		Start:     time.Unix(1, 0),
 		End:       time.Unix(2, 0),
 		Activity:  1,


### PR DESCRIPTION
* upd: Added support for `_count_only` requests using the FindTags functions.