### PR TITLE
Tidying up the Go Docs

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/activity_test.go
+++ b/activity_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/caql.go
+++ b/caql.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/caql_test.go
+++ b/caql_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/client.go
+++ b/client.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/client.go
+++ b/client.go
@@ -242,7 +242,7 @@ func NewClient(cfg *Config) (*SnowthClient, error) {
 	return sc, nil
 }
 
-// Retires gets the number of retries a SnowthClient will attempt when
+// Retries gets the number of retries a SnowthClient will attempt when
 // errors other than connection errors occur with a snowth node.
 // Retires will repeat the request with exponential backoff until this number
 // of retries is reached.
@@ -252,7 +252,7 @@ func (sc *SnowthClient) Retries() int64 {
 	return sc.retries
 }
 
-// SetRetires gets the number of retries a SnowthClient will attempt when
+// SetRetries gets the number of retries a SnowthClient will attempt when
 // errors other than connection errors occur with a snowth node.
 // Retires will repeat the request with exponential backoff until this number
 // of retries is reached.
@@ -262,7 +262,7 @@ func (sc *SnowthClient) SetRetries(num int64) {
 	sc.retries = num
 }
 
-// ConnectRetires gets the number of retries a SnowthClient will attempt when
+// ConnectRetries gets the number of retries a SnowthClient will attempt when
 // connection errors occur to a snowth node. When a connection error occurs
 // the affected node will be deactivated, then a retries will happen on
 // another node. A value of -1 will retry until no nodes are available,
@@ -274,7 +274,7 @@ func (sc *SnowthClient) ConnectRetries() int64 {
 	return sc.connRetries
 }
 
-// SetConnectRetires sets the number of retries a SnowthClient will attempt when
+// SetConnectRetries sets the number of retries a SnowthClient will attempt when
 // connection errors occur to a snowth node. When a connection error occurs
 // the affected node will be deactivated, then a retries will happen on
 // another node. A value of -1 will retry until no nodes are available,

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/common.go
+++ b/common.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/common_test.go
+++ b/common_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/config.go
+++ b/config.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/df4.go
+++ b/df4.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/df4_test.go
+++ b/df4_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+/*
+Package gosnowth contains an IRONdb client library written in Go.
+
+Examples can be found at github.com/circonus-labs/gosnowth/tree/master/examples
+*/
+package gosnowth

--- a/fetch.go
+++ b/fetch.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/gossip.go
+++ b/gossip.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/histogram.go
+++ b/histogram.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/location.go
+++ b/location.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/location_test.go
+++ b/location_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/lua.go
+++ b/lua.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/lua_test.go
+++ b/lua_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/nnt.go
+++ b/nnt.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/nnt_test.go
+++ b/nnt_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/numeric.go
+++ b/numeric.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/raw.go
+++ b/raw.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/rollup.go
+++ b/rollup.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/state.go
+++ b/state.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/state_test.go
+++ b/state_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/stats.go
+++ b/stats.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/tags.go
+++ b/tags.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/text.go
+++ b/text.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/text_test.go
+++ b/text_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/topology.go
+++ b/topology.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (

--- a/topology_test.go
+++ b/topology_test.go
@@ -1,4 +1,3 @@
-// Package gosnowth contains an IRONdb client library written in Go.
 package gosnowth
 
 import (


### PR DESCRIPTION
There was an issue I noticed when viewing the docs at pgk.go.dev, the package topline was defined in multiple files so it was repeating that declaration on the docs site. I added doc.go as a single place to add/edit the top-level package description as well as fixed a few small typos that were causing linting warnings (retires instead of retries in client.go)