### PR TITLE
CIRC-6535: Add X-Snowth-Timeout header

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.8.1] - 2021-05-05
+
+* upd: Requests to IRONdb will now include a X-Snowth-Timeout header. The value
+will be 1 second less than the total request timeout configuration value.
+
 ## [v1.8.0] - 2021-04-13
 
 * add: Incorporates a `SnowthClient.WriteNNTBSFlatbuffer()` API for writing

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/circonus-labs/circonusllhist"
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/google/uuid"
+	"github.com/openhistogram/circonusllhist"
 
 	"github.com/circonus-labs/gosnowth"
 	"github.com/circonus-labs/gosnowth/fb/noit"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/circonus-labs/gosnowth
 go 1.14
 
 require (
-	github.com/circonus-labs/circonusllhist v0.1.4
 	github.com/google/flatbuffers v1.12.0
 	github.com/google/uuid v1.1.1
+	github.com/openhistogram/circonusllhist v0.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/circonus-labs/circonusllhist v0.1.4 h1:G5qJPuD16akpIXMUR7KcfBvrQOVm95+qyqUm+SEAZks=
-github.com/circonus-labs/circonusllhist v0.1.4/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oogeh6w=
 github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/openhistogram/circonusllhist v0.2.1 h1:x3U4T8CL+RyLq+PNqZ4g9WMCEYuZ3qlD7m+zkIQ6QYI=
+github.com/openhistogram/circonusllhist v0.2.1/go.mod h1:PfeYJ/RW2+Jfv3wTz0upbY2TRour/LLqIm2K2Kw5zg0=

--- a/histogram.go
+++ b/histogram.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/circonus-labs/circonusllhist"
+	"github.com/openhistogram/circonusllhist"
 )
 
 // HistogramValue values are individual data points of a histogram metric.


### PR DESCRIPTION
* upd: Requests to IRONdb will now include a X-Snowth-Timeout header. The value will be 1 second less than the total request timeout configuration value.