### PR TITLE
CIRC-7239: Add support for time strings to tags, linter fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
       - ineffassign
       - interfacer
       - lll
-        #- maligned
+      - maligned
       - misspell
       - nakedret
       - prealloc

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+* add: Added support for start and end time strings to the tags API.
+
 ## [v1.10.0] - 2021-06-14
 
 * add: Added functions implementing access to the IRONdb read graphite API:

--- a/caql.go
+++ b/caql.go
@@ -11,39 +11,39 @@ import (
 
 // CAQLQuery values represent CAQL queries and associated parameters.
 type CAQLQuery struct {
-	Format               string   `json:"format,omitempty"`
-	Query                string   `json:"q,omitempty"`
+	Explain              bool     `json:"explain"`
+	IgnoreDurationLimits bool     `json:"ignore_duration_limits,omitempty"`
+	Debug                byte     `json:"_debug,omitempty"`
 	Period               int64    `json:"period,omitempty"`
 	ID                   int64    `json:"_id,omitempty"`
-	IgnoreDurationLimits bool     `json:"ignore_duration_limits,omitempty"`
-	PrepareResults       string   `json:"prepare_results,omitempty"`
 	AccountID            int64    `json:"account_id,string,omitempty"`
-	Method               string   `json:"method,omitempty"`
 	Start                int64    `json:"start_time,omitempty"`
 	Timeout              int64    `json:"_timeout,omitempty"`
 	MinPrefill           int64    `json:"min_prefill,omitempty"`
-	Debug                byte     `json:"_debug,omitempty"`
-	Expansion            []string `json:"expansion,omitempty"`
 	End                  int64    `json:"end_time,omitempty"`
-	Explain              bool     `json:"explain"`
+	Format               string   `json:"format,omitempty"`
+	Query                string   `json:"q,omitempty"`
+	PrepareResults       string   `json:"prepare_results,omitempty"`
+	Method               string   `json:"method,omitempty"`
+	Expansion            []string `json:"expansion,omitempty"`
 }
 
 // CAQLErrorArgs values represent CAQL request arguments returned in an error.
 type CAQLErrorArgs struct {
-	Format               string   `json:"format"`
-	Query                string   `json:"q"`
+	IgnoreDurationLimits bool     `json:"ignore_duration_limits"`
+	Debug                byte     `json:"_debug"`
 	Period               int64    `json:"period"`
 	ID                   int64    `json:"_id"`
-	IgnoreDurationLimits bool     `json:"ignore_duration_limits"`
-	PrepareResults       string   `json:"prepare_results"`
 	AccountID            int64    `json:"account_id,string"`
-	Method               string   `json:"method"`
 	Start                int64    `json:"start_time"`
 	Timeout              int64    `json:"_timeout"`
 	MinPrefill           int64    `json:"min_prefill"`
-	Debug                byte     `json:"_debug"`
-	Expansion            []string `json:"expansion"`
 	End                  int64    `json:"end_time"`
+	Format               string   `json:"format"`
+	Query                string   `json:"q"`
+	PrepareResults       string   `json:"prepare_results"`
+	Method               string   `json:"method"`
+	Expansion            []string `json:"expansion"`
 }
 
 // CAQLUserError values contain messages describing a CAQL error for a user.
@@ -52,7 +52,7 @@ type CAQLUserError struct {
 }
 
 // CAQLError values contain information about an error returned by the CAQL
-//extension.
+// extension.
 type CAQLError struct {
 	Locals    []string      `json:"locals"`
 	Method    string        `json:"method"`
@@ -119,7 +119,8 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 	}
 
 	r := &DF4Response{}
-	body, _, err := sc.DoRequestContext(ctx, node, "POST", u, bytes.NewBuffer(bBuf), nil)
+	body, _, err := sc.DoRequestContext(ctx, node, "POST", u,
+		bytes.NewBuffer(bBuf), nil)
 	if err != nil {
 		if body != nil {
 			cErr := &CAQLError{}

--- a/caql_test.go
+++ b/caql_test.go
@@ -18,20 +18,20 @@ const testCAQLError = `{
 	},
 	"status": "520 (User facing error)",
 	"arguments": {
-		"format": "DF4",
-		"q": "find:histograms(\"latency\",\"and(service:api)\")",
+		"ignore_duration_limits": false,
+		"_debug": 0,
 		"period": 300,
 		"_id": 33545929,
-		"ignore_duration_limits": false,
-		"prepare_results": "JSON",
 		"account_id": "1",
-		"method": "fetch",
 		"start_time": 1567500000,
 		"_timeout": 15,
 		"min_prefill": 0,
-		"_debug": 0,
-		"expansion": [],
-		"end_time": 1567566000
+		"end_time": 1567566000,
+		"format": "DF4",
+		"q": "find:histograms(\"latency\",\"and(service:api)\")",
+		"prepare_results": "JSON",
+		"method": "fetch",
+		"expansion": []
 	},
 	"success": false
 }`
@@ -138,7 +138,7 @@ func TestGetCAQLQuery(t *testing.T) {
 
 	vErr, ok := err.(*CAQLError)
 	if !ok {
-		t.Fatalf("Expected error type: CAQLError, got: %T", err)
+		t.Fatalf("Expected error type: CAQLError, got: %T: %v", err, err)
 	}
 
 	exp := "Function not found: histograms"
@@ -147,10 +147,10 @@ func TestGetCAQLQuery(t *testing.T) {
 			vErr.UserError.Message)
 	}
 
-	exp = strings.Replace(strings.Replace(strings.Replace(testCAQLError,
-		" ", "", -1), "\t", "", -1), "\n", "", -1)
-	val := strings.Replace(strings.Replace(strings.Replace(vErr.Error(),
-		" ", "", -1), "\t", "", -1), "\n", "", -1)
+	exp = strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		testCAQLError, " ", ""), "\t", ""), "\n", "")
+	val := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		vErr.Error(), " ", ""), "\t", ""), "\n", "")
 	if val != exp {
 		t.Errorf("Expected error JSON: %v, got: %v", exp, val)
 	}

--- a/client.go
+++ b/client.go
@@ -699,9 +699,11 @@ func (sc *SnowthClient) ListActiveNodes() []*SnowthNode {
 func (sc *SnowthClient) GetActiveNode(idsets ...[]string) *SnowthNode {
 	sc.RLock()
 	defer sc.RUnlock()
+
 	if len(sc.activeNodes) == 0 {
 		return nil
 	}
+
 	for _, ids := range idsets {
 		for _, id := range ids {
 			for _, node := range sc.activeNodes {
@@ -711,7 +713,8 @@ func (sc *SnowthClient) GetActiveNode(idsets ...[]string) *SnowthNode {
 			}
 		}
 	}
-	return sc.activeNodes[rand.Intn(len(sc.activeNodes))]
+
+	return sc.activeNodes[rand.Intn(len(sc.activeNodes))] // nolint gosec
 }
 
 // DoRequest sends a request to IRONdb.
@@ -841,7 +844,7 @@ func (sc *SnowthClient) do(ctx context.Context, node *SnowthNode,
 	// Send a header telling snowth to use the gosnowth timeout - 1 second.
 	if sc.timeout > 0 {
 		if (sc.timeout - time.Second) > 0 {
-			to := time.Duration(sc.timeout - time.Second)
+			to := sc.timeout - time.Second
 
 			r.Header.Set("X-Snowth-Timeout", to.String())
 		} else {

--- a/df4.go
+++ b/df4.go
@@ -63,37 +63,37 @@ func replaceInf(b []byte) []byte {
 	v := make([]byte, len(b))
 	copy(v, b)
 
-	v = bytes.Replace(v, []byte("+inf,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
-	v = bytes.Replace(v, []byte("+inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
-	v = bytes.Replace(v, []byte("+inf\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
-	v = bytes.Replace(v, []byte("-inf,"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","), -1)
-	v = bytes.Replace(v, []byte("-inf]"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"]"), -1)
-	v = bytes.Replace(v, []byte("-inf\n"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
-	v = bytes.Replace(v, []byte("inf,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
-	v = bytes.Replace(v, []byte("inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
-	v = bytes.Replace(v, []byte("inf\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
+	v = bytes.ReplaceAll(v, []byte("+inf,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
+	v = bytes.ReplaceAll(v, []byte("+inf]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
+	v = bytes.ReplaceAll(v, []byte("+inf\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
+	v = bytes.ReplaceAll(v, []byte("-inf,"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","))
+	v = bytes.ReplaceAll(v, []byte("-inf]"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"]"))
+	v = bytes.ReplaceAll(v, []byte("-inf\n"), []byte(
+		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"\n"))
+	v = bytes.ReplaceAll(v, []byte("inf,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
+	v = bytes.ReplaceAll(v, []byte("inf]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
+	v = bytes.ReplaceAll(v, []byte("inf\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
 
-	v = bytes.Replace(v, []byte("NaN,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
-	v = bytes.Replace(v, []byte("NaN]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
-	v = bytes.Replace(v, []byte("NaN\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
-	v = bytes.Replace(v, []byte("nan,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","), -1)
-	v = bytes.Replace(v, []byte("nan]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"), -1)
-	v = bytes.Replace(v, []byte("nan\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"), -1)
+	v = bytes.ReplaceAll(v, []byte("NaN,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
+	v = bytes.ReplaceAll(v, []byte("NaN]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
+	v = bytes.ReplaceAll(v, []byte("NaN\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
+	v = bytes.ReplaceAll(v, []byte("nan,"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
+	v = bytes.ReplaceAll(v, []byte("nan]"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
+	v = bytes.ReplaceAll(v, []byte("nan\n"), []byte(
+		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
 
 	return v
 }

--- a/df4_test.go
+++ b/df4_test.go
@@ -92,8 +92,8 @@ func TestMarshalDF4Response(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exp := strings.Replace(strings.Replace(strings.Replace(testDF4Response,
-		"\n", "", -1), " ", "", -1), "\t", "", -1) + "\n"
+	exp := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		testDF4Response, "\n", ""), " ", ""), "\t", "") + "\n"
 	if buf.String() != exp {
 		t.Errorf("Expected JSON: %s, got: %s", exp, buf.String())
 	}

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -77,8 +77,8 @@ func TestFetchQueryMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exp := strings.Replace(strings.Replace(strings.Replace(fetchTestQuery,
-		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	exp := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		fetchTestQuery, " ", ""), "\n", ""), "\t", "") + "\n"
 	if buf.String() != exp {
 		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
 	}

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -73,8 +73,8 @@ func TestHistogramValueMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exp := strings.Replace(strings.Replace(strings.Replace(histogramTestData,
-		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	exp := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		histogramTestData, " ", ""), "\n", ""), "\t", "") + "\n"
 	if buf.String() != exp {
 		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
 	}

--- a/location_test.go
+++ b/location_test.go
@@ -25,6 +25,7 @@ const locateXMLTestData = `<nodes n="2">
 		side="both"/>
 </nodes>`
 
+/*
 const locateTopologyXMLTestData = `<nodes n="3">
 	<node id="5c32c076-ffeb-cfdd-a541-97e25c028dd6"
 		address="10.0.0.100"
@@ -87,6 +88,7 @@ const locateTopologyXMLTestData = `<nodes n="3">
 		weight="51"
 		side="b"/>
 </nodes>`
+*/
 
 func TestDataLocationXMLDeserialization(t *testing.T) {
 	dec := xml.NewDecoder(bytes.NewBufferString(locateXMLTestData))

--- a/nntbs.go
+++ b/nntbs.go
@@ -14,7 +14,9 @@ import (
 
 const metricSourceGraphite = 0x2
 
-var nntMergeFileIdentifier = []byte("CINN")
+func nntMergeFileIdentifier() []byte {
+	return []byte("CINN")
+}
 
 // WriteNNTBSFlatbuffer writes flatbuffer format NNTBS data to an IRONdb node.
 func (sc *SnowthClient) WriteNNTBSFlatbuffer(merge *nntbs.NNTMergeT,
@@ -48,7 +50,7 @@ func (sc *SnowthClient) WriteNNTBSFlatbufferContext(ctx context.Context,
 	}
 
 	offset := nntbs.NNTMergePack(builder, merge)
-	builder.FinishWithFileIdentifier(offset, nntMergeFileIdentifier)
+	builder.FinishWithFileIdentifier(offset, nntMergeFileIdentifier())
 
 	data := builder.FinishedBytes()
 	hdrs := http.Header{"Content-Type": {"application/snowth-nntbs"}}

--- a/nntbs_test.go
+++ b/nntbs_test.go
@@ -66,7 +66,7 @@ func TestWriteNNTBSFlatbuffer(t *testing.T) {
 
 	merge := &nntbs.NNTMergeT{
 		Ops: []*nntbs.NNTMergeOpT{
-			&nntbs.NNTMergeOpT{
+			{
 				Metric: &nntbs.MetricInfoT{
 					MetricLocator: &nntbs.MetricLocatorT{
 						CheckUuid:  []byte("11223344-5566-7788-9900-aabbccddeeff"),
@@ -77,12 +77,12 @@ func TestWriteNNTBSFlatbuffer(t *testing.T) {
 					CheckCategory: metricSourceGraphite,
 				},
 				Nnt: []*nntbs.NNTT{
-					&nntbs.NNTT{
+					{
 						Epoch:      uint64(0),
 						Apocalypse: uint64(300),
 						Period:     uint32(60),
 						Blocks: []*nntbs.NNTBlockT{
-							&nntbs.NNTBlockT{
+							{
 								Data: []*nntbs.NNTDatumT{{
 									Zero:             false,
 									Count:            0,

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -149,8 +149,8 @@ func TestRollupAllValueMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exp := strings.Replace(strings.Replace(strings.Replace(rollupAllTestData,
-		" ", "", -1), "\n", "", -1), "\t", "", -1) + "\n"
+	exp := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
+		rollupAllTestData, " ", ""), "\n", ""), "\t", "") + "\n"
 	if buf.String() != exp {
 		t.Errorf("Expected JSON: %v, got: %v", exp, buf.String())
 	}

--- a/tags.go
+++ b/tags.go
@@ -229,11 +229,11 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 	}
 
 	if options.StartStr != "" {
-		starts = options.StartStr
+		starts = url.QueryEscape(options.StartStr)
 	}
 
 	if options.EndStr != "" {
-		ends = options.EndStr
+		ends = url.QueryEscape(options.EndStr)
 	}
 
 	if starts != "" {
@@ -253,7 +253,8 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 
 	hdrs := http.Header{}
 	if options.Limit != 0 {
-		hdrs.Set("X-Snowth-Advisory-Limit", strconv.FormatInt(options.Limit, 10))
+		hdrs.Set("X-Snowth-Advisory-Limit",
+			strconv.FormatInt(options.Limit, 10))
 	}
 
 	r := &FindTagsResult{}

--- a/tags.go
+++ b/tags.go
@@ -43,12 +43,14 @@ type FindTagsCount struct {
 // FindTagsOptions values contain optional parameters to be passed to the
 // IRONdb find tags call by a FindTags operation.
 type FindTagsOptions struct {
-	Start     time.Time `json:"activity_start_secs"`
-	End       time.Time `json:"activity_end_secs"`
-	Activity  int64     `json:"activity"`
-	Latest    int64     `json:"latest"`
-	CountOnly int64     `json:"count_only"`
-	Limit     int64     `json:"limit"`
+	Start     time.Time
+	End       time.Time
+	StartStr  string `json:"activity_start_secs"`
+	EndStr    string `json:"activity_end_secs"`
+	Activity  int64  `json:"activity"`
+	Latest    int64  `json:"latest"`
+	CountOnly int64  `json:"count_only"`
+	Limit     int64  `json:"limit"`
 }
 
 // FindTagsLatest values contain the most recent data values for a metric.
@@ -216,14 +218,35 @@ func (sc *SnowthClient) FindTagsContext(ctx context.Context, accountID int64,
 	u := fmt.Sprintf("%s?query=%s",
 		sc.getURL(node, fmt.Sprintf("/find/%d/tags", accountID)),
 		url.QueryEscape(query))
-	if !options.Start.IsZero() && !options.End.IsZero() &&
-		options.Start.Unix() != 0 && options.End.Unix() != 0 {
-		u += fmt.Sprintf("&activity_start_secs=%s&activity_end_secs=%s",
-			formatTimestamp(options.Start), formatTimestamp(options.End))
+
+	starts, ends := "", ""
+	if !options.Start.IsZero() && options.Start.Unix() != 0 {
+		starts = formatTimestamp(options.Start)
+	}
+
+	if !options.End.IsZero() && options.End.Unix() != 0 {
+		ends = formatTimestamp(options.End)
+	}
+
+	if options.StartStr != "" {
+		starts = options.StartStr
+	}
+
+	if options.EndStr != "" {
+		ends = options.EndStr
+	}
+
+	if starts != "" {
+		u += fmt.Sprintf("&activity_start_secs=%s", starts)
+	}
+
+	if ends != "" {
+		u += fmt.Sprintf("&activity_end_secs=%s", ends)
 	}
 
 	u += fmt.Sprintf("&activity=%d", options.Activity)
 	u += fmt.Sprintf("&latest=%d", options.Latest)
+
 	if options.CountOnly != 0 {
 		u += fmt.Sprintf("&count_only=%d", options.CountOnly)
 	}
@@ -440,12 +463,14 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 
 	ex, ok := old[checkUUID]
 	if !ok {
-		return 0, fmt.Errorf("failed to retrive existing check tags: %v",
+		return 0, fmt.Errorf("failed to retrieve existing check tags: %v",
 			checkUUID)
 	}
 
 	if len(tags) == 0 {
-		sc.DeleteCheckTagsContext(ctx, checkUUID)
+		if err := sc.DeleteCheckTagsContext(ctx, checkUUID); err != nil {
+			return 0, err
+		}
 
 		return 0, nil
 	}
@@ -514,16 +539,8 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 
 // encodeTags performs base64 encoding on tags when needed.
 func encodeTags(tags []string) ([]string, error) {
-	keyTest, err := regexp.Compile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-]*$")
-	if err != nil {
-		return nil, fmt.Errorf("unable to compile key test regexp: %w", err)
-	}
-
-	valTest, err := regexp.Compile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-:=]*$")
-	if err != nil {
-		return nil, fmt.Errorf("unable to compile value test regexp: %w", err)
-	}
-
+	keyTest := regexp.MustCompile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-]*$")
+	valTest := regexp.MustCompile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-:=]*$")
 	res := []string{}
 
 	for _, tag := range tags {
@@ -550,8 +567,8 @@ func encodeTags(tags []string) ([]string, error) {
 
 			rk = string(key)
 
-			if keyTest.Match([]byte(key)) {
-				rk = `b"` + base64.StdEncoding.EncodeToString([]byte(key)) +
+			if keyTest.Match(key) {
+				rk = `b"` + base64.StdEncoding.EncodeToString(key) +
 					`"`
 			}
 		} else {
@@ -570,8 +587,8 @@ func encodeTags(tags []string) ([]string, error) {
 
 			rv = string(val)
 
-			if valTest.Match([]byte(val)) {
-				rv = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) +
+			if valTest.Match(val) {
+				rv = `b"` + base64.StdEncoding.EncodeToString(val) +
 					`"`
 			}
 		} else {

--- a/tags_test.go
+++ b/tags_test.go
@@ -152,6 +152,30 @@ func TestFindTags(t *testing.T) {
 	}
 
 	res, err = sc.FindTags(1, "test", &FindTagsOptions{
+		StartStr:  "now - 1mon",
+		EndStr:    "now - 1d",
+		Activity:  1,
+		Latest:    1,
+		CountOnly: 0,
+		Limit:     -1,
+	}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Count != 1 {
+		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+	}
+
+	if len(res.Items) != 1 {
+		t.Fatalf("Expected result length: 1, got: %v", len(res.Items))
+	}
+
+	if res.Items[0].MetricName != "test" {
+		t.Errorf("Expected metric name: test, got: %v", res.Items[0].MetricName)
+	}
+
+	res, err = sc.FindTags(1, "test", &FindTagsOptions{
 		StartStr:  "now-1d",
 		EndStr:    "now",
 		Activity:  1,

--- a/tags_test.go
+++ b/tags_test.go
@@ -152,8 +152,8 @@ func TestFindTags(t *testing.T) {
 	}
 
 	res, err = sc.FindTags(1, "test", &FindTagsOptions{
-		Start:     time.Unix(1, 0),
-		End:       time.Unix(2, 0),
+		StartStr:  "now-1d",
+		EndStr:    "now",
 		Activity:  1,
 		Latest:    1,
 		CountOnly: 0,

--- a/topology_test.go
+++ b/topology_test.go
@@ -135,6 +135,7 @@ func TestTopologyXMLSerialization(t *testing.T) {
 	}
 }
 
+/*
 func checkLocationAgainstNode(t *testing.T, sc *SnowthClient, uuid string, metric string) {
 	intnodes, err := sc.LocateMetric(uuid, metric)
 	if err != nil {
@@ -156,19 +157,7 @@ func checkLocationAgainstNode(t *testing.T, sc *SnowthClient, uuid string, metri
 		}
 	}
 }
-func BenchmarkLookup1(b *testing.B) {
-	b.StopTimer()
-	id := uuid.New().String()
-	topo, err := TopologyLoadXML(topologyXMLTestData)
-	if err != nil {
-		b.Fatal("cannot load topology for benchmark")
-	}
-	b.StartTimer()
-	for n := 0; n < b.N; n++ {
-		_, _ = topo.FindMetric(id,
-			"this.is.a.metric|ST[nice:andhappy,with:tags]")
-	}
-}
+*/
 
 /*
 func TestLiveNode(t *testing.T) {
@@ -192,6 +181,20 @@ func TestLiveNode(t *testing.T) {
 	}
 }
 */
+
+func BenchmarkLookup1(b *testing.B) {
+	b.StopTimer()
+	id := uuid.New().String()
+	topo, err := TopologyLoadXML(topologyXMLTestData)
+	if err != nil {
+		b.Fatal("cannot load topology for benchmark")
+	}
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = topo.FindMetric(id,
+			"this.is.a.metric|ST[nice:andhappy,with:tags]")
+	}
+}
 
 func TestTopology(t *testing.T) {
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,


### PR DESCRIPTION
* add: Added support for start and end time strings to the tags API.
* fix: Struct alignments, ReplaceAll, and other linter fixes.