### PR TITLE
CIRC-8083: Randomize IRONdb nodes to retry on network errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.10.3] - 2022-04-11
+
+* upd: Randomizes the IRONdb cluster nodes that will be retried in cases of
+network connection failure.
+
 ## [v1.10.2] - 2021-12-03
 
 * add: Added metric name parsing functionality via the ParseMetricName function

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,8 +6,9 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
-## [v1.10.3] - 2022-04-11
+## [v1.10.3] - 2022-04-12
 
+* upd: Adds retry number and trace ID to request debug log entries.
 * upd: Randomizes the IRONdb cluster nodes that will be retried in cases of
 network connection failure.
 

--- a/client.go
+++ b/client.go
@@ -748,7 +748,7 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 	}
 
 	cr := sc.ConnectRetries()
-	nodes := sc.ListActiveNodes()
+	nodes := append([]*SnowthNode{node}, sc.ListActiveNodes()...)
 	var bdy io.Reader
 	var hdr http.Header
 

--- a/client.go
+++ b/client.go
@@ -819,7 +819,9 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 			}
 		}
 
-		time.Sleep(time.Millisecond * time.Duration(100*2^r))
+		if r < retries {
+			time.Sleep(time.Millisecond * time.Duration(100*2^r))
+		}
 	}
 
 	return bdy, hdr, err


### PR DESCRIPTION
* upd: Randomizes the IRONdb cluster nodes that will be retried in cases of network connection failure.