### PR TITLE
CIRC-8169: Support context termination in NewClient()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.10.4] - 2022-04-14
+
+* upd: NewClient() now requires a context when being called. This allows for
+context terminations to happen during the process of creating and initializing
+a new SnowthClient.
+
 ## [v1.10.3] - 2022-04-12
 
 * upd: Adds retry number and trace ID to request debug log entries.

--- a/caql_test.go
+++ b/caql_test.go
@@ -83,7 +83,8 @@ func TestGetCAQLQuery(t *testing.T) {
 
 	sc.SetRetries(1)
 	sc.SetConnectRetries(1)
-	u, err := url.Parse("http://invalid")
+
+	u, err := url.Parse(ms.URL)
 	if err != nil {
 		t.Fatal("Invalid test URL")
 	}


### PR DESCRIPTION
* upd: NewClient() now requires a context when being called. This allows for context terminations to happen during the process of creating and initializing a new SnowthClient.