### PR TITLE
CIRC-8303: Fix measurement tag parsing to use curly brackets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 * fix: Fixes the metric name parser to correctly use curly brackets when
 parsing measurement tags.
-* fix: Fixes connetion retries to always try the specified node first then
+* fix: Fixes connection retries to always try the specified node first then
 randomly pick from active cluster nodes for retries.
 * fix: Fixes broken examples code.
 
@@ -347,6 +347,9 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.10.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.5
+[v1.10.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.4
+[v1.10.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.3
 [v1.10.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.2
 [v1.10.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.1
 [v1.10.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,14 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.10.5] - 2022-05-03
+
+* fix: Fixes the metric name parser to correctly use curly brackets when
+parsing measurement tags.
+* fix: Fixes connetion retries to always try the specified node first then
+randomly pick from active cluster nodes for retries.
+* fix: Fixes broken examples code.
+
 ## [v1.10.4] - 2022-04-14
 
 * upd: NewClient() now requires a context when being called. This allows for

--- a/client.go
+++ b/client.go
@@ -757,7 +757,11 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 		surl := url
 		sns := nodes
 		for len(sns) > 0 {
-			n := time.Now().UnixNano() % int64(len(sns))
+			n := int64(0)
+			if connRetries != cr {
+				n = time.Now().UnixNano() % int64(len(sns))
+			}
+
 			sn := sns[n]
 			sns[n] = sns[len(sns)-1]
 			sns = sns[:len(sns)-1]

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"strconv"
@@ -20,7 +21,7 @@ func ExampleReadNNT() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -68,7 +69,7 @@ func ExampleReadText() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/state.go
+++ b/examples/state.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/circonus-labs/gosnowth"
@@ -16,7 +17,7 @@ func ExampleGetNodeState() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -41,7 +42,7 @@ func ExampleGetNodeGossip() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -66,7 +67,7 @@ func ExampleGetTopology() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"strconv"
@@ -24,7 +25,7 @@ func ExampleSubmitText() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -51,7 +52,7 @@ func ExampleSubmitNNT() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}
@@ -87,7 +88,7 @@ func ExampleSubmitHistogram() {
 	}
 
 	cfg.SetDiscover(true)
-	client, err := gosnowth.NewClient(cfg)
+	client, err := gosnowth.NewClient(context.Background(), cfg)
 	if err != nil {
 		log.Fatalf("failed to create snowth client: %v", err)
 	}

--- a/metric_test.go
+++ b/metric_test.go
@@ -46,6 +46,16 @@ func TestScanMetricName(t *testing.T) {
 			tok:   tokenMetric,
 			lit:   "testing",
 		},
+		{
+			input: "testing|MT{test:test}",
+			tok:   tokenMetric,
+			lit:   "testing",
+		},
+		{
+			input: "testing|ST[blah:blah]|MT{test:test}",
+			tok:   tokenMetric,
+			lit:   "testing",
+		},
 	}
 
 	for _, c := range cases {
@@ -94,7 +104,7 @@ func TestScanTagSep(t *testing.T) {
 		t.Error("incorrect literal scanned: ", lit)
 	}
 
-	mtBuf := bytes.NewBufferString("|MT[blah:blah]")
+	mtBuf := bytes.NewBufferString("|MT{blah:blah}")
 	s = newMetricScanner(mtBuf)
 	tok, lit, err = s.peekTagSep()
 	if err != nil {
@@ -197,37 +207,37 @@ func TestMetricParser(t *testing.T) {
 			lit:   "testing",
 		},
 		{
-			input: "testing|MT[blah:blah]",
+			input: "testing|MT{blah:blah}",
 			numST: 0,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: "testing|ST[blah:blah]|MT[blah:blah]",
+			input: "testing|ST[blah:blah]|MT{blah:blah}",
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: "testing|ST[blah:blah]|MT[blah:blah]|ST[blah:blah]",
+			input: "testing|ST[blah:blah]|MT{blah:blah}|ST[blah:blah]",
 			numST: 2,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah:|ST[]":blah]|MT[blah:",]:|MTblah"]`,
+			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah:|ST[]":blah]|MT[blah:",]:|MTblah"]`,
+			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["b:|ST[]":b]|MT[b:",]:|MTb"]|ST[a:b]|MT[c:d]`,
+			input: `testing|ST["b:|ST[]":b]|MT{b:",}:|MTb"}|ST[a:b]|MT{c:d}`,
 			numST: 2,
 			numMT: 2,
 			lit:   "testing",
@@ -239,7 +249,7 @@ func TestMetricParser(t *testing.T) {
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["quote\"slash\\":bar]|MT["q\\\"\\:":bar]`,
+			input: `testing|ST["quote\"slash\\":bar]|MT{"q\\\"\\:":bar}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",


### PR DESCRIPTION
* fix: Fixes the metric name parser to correctly use curly brackets when parsing measurement tags.
* fix: Fixes connection retries to always try the specified node first then randomly pick from active cluster nodes for retries.
* fix: Fixes broken examples code.