### PR TITLE
CIRC-8570: Make context terminated check compatible with go 1.19

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.10.10] - 2022-06-15
+
+* upd: Changes the method used to stop retrying when contexts are canceled
+or reach timeout. This is to support upcoming changes in go v1.19.
+
 ## [v1.10.9] - 2022-06-14
 
 * upd: Improves request handling so that requests are not retried for 4XX
@@ -371,6 +376,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.10.10]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.10
 [v1.10.9]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.9
 [v1.10.8]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.8
 [v1.10.7]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.7


### PR DESCRIPTION
* upd: Changes the method used to stop retrying when contexts are canceled or reach timeout. This is to support upcoming changes in go v1.19.
* This is needed because in go v1.19 network cancellation and timeout errors from the net package will return true for errors.Is(err, context.DeadlineExceeded) or errors.Is(err, context.Canceled), and the current check would stop processing connection retries for some of the exact connection errors where we do want to be processing retries even though the context for DoRequestTimeout() has still not terminated. See: https://tip.golang.org/doc/go1.19.