### PR TITLE
CIRC-3356: Fix issue with check tags base64 encoding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.10.11] - 2022-07-15
+
+* fix: Corrects a bug in how check tag encoding is handled that was preventing
+UpdateCheckTags() from correctly updating check tags requiring base64 encoding.
+
 ## [v1.10.10] - 2022-06-15
 
 * upd: Changes the method used to stop retrying when contexts are canceled
@@ -376,6 +381,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.10.11]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.11
 [v1.10.10]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.10
 [v1.10.9]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.9
 [v1.10.8]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.8

--- a/tags.go
+++ b/tags.go
@@ -570,14 +570,13 @@ func encodeTags(tags []string) ([]string, error) {
 			continue
 		}
 
-		rk, rv := "", ""
-
 		parts := strings.SplitN(tag, ":", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid tag passed: %v", tag)
 		}
 
 		key := parts[0]
+
 		if strings.HasPrefix(key, `b"`) && strings.HasSuffix(key, `"`) {
 			key = strings.TrimPrefix(strings.TrimSuffix(key, `"`), `b"`)
 
@@ -586,18 +585,14 @@ func encodeTags(tags []string) ([]string, error) {
 				return nil, fmt.Errorf("invalid base64 tag key: %v %w",
 					key, err)
 			}
+		}
 
-			rk = string(key)
-
-			if keyTest.Match(key) {
-				rk = `b"` + base64.StdEncoding.EncodeToString(key) +
-					`"`
-			}
-		} else {
-			rk = key
+		if !keyTest.MatchString(key) {
+			key = `b"` + base64.StdEncoding.EncodeToString([]byte(key)) + `"`
 		}
 
 		val := parts[1]
+
 		if strings.HasPrefix(val, `b"`) && strings.HasSuffix(val, `"`) {
 			val = strings.TrimPrefix(strings.TrimSuffix(val, `"`), `b"`)
 
@@ -606,18 +601,13 @@ func encodeTags(tags []string) ([]string, error) {
 				return nil, fmt.Errorf("invalid base64 tag value: %v %w",
 					val, err)
 			}
-
-			rv = string(val)
-
-			if valTest.Match(val) {
-				rv = `b"` + base64.StdEncoding.EncodeToString(val) +
-					`"`
-			}
-		} else {
-			rv = val
 		}
 
-		res = append(res, rk+":"+rv)
+		if !valTest.MatchString(val) {
+			val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
+		}
+
+		res = append(res, key+":"+val)
 	}
 
 	return res, nil

--- a/tags.go
+++ b/tags.go
@@ -575,20 +575,20 @@ func encodeTags(tags []string) ([]string, error) {
 			return nil, fmt.Errorf("invalid tag passed: %v", tag)
 		}
 
-		key := parts[0]
+		cat := parts[0]
 
-		if strings.HasPrefix(key, `b"`) && strings.HasSuffix(key, `"`) {
-			key = strings.TrimPrefix(strings.TrimSuffix(key, `"`), `b"`)
+		if strings.HasPrefix(cat, `b"`) && strings.HasSuffix(cat, `"`) {
+			cat = strings.TrimPrefix(strings.TrimSuffix(cat, `"`), `b"`)
 
-			key, err := base64.StdEncoding.DecodeString(key)
+			cat, err := base64.StdEncoding.DecodeString(cat)
 			if err != nil {
-				return nil, fmt.Errorf("invalid base64 tag key: %v %w",
-					key, err)
+				return nil, fmt.Errorf("invalid base64 tag category: %v %w",
+					cat, err)
 			}
 		}
 
-		if !keyTest.MatchString(key) {
-			key = `b"` + base64.StdEncoding.EncodeToString([]byte(key)) + `"`
+		if !keyTest.MatchString(cat) {
+			cat = `b"` + base64.StdEncoding.EncodeToString([]byte(cat)) + `"`
 		}
 
 		val := parts[1]
@@ -607,7 +607,7 @@ func encodeTags(tags []string) ([]string, error) {
 			val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
 		}
 
-		res = append(res, key+":"+val)
+		res = append(res, cat+":"+val)
 	}
 
 	return res, nil

--- a/tags.go
+++ b/tags.go
@@ -561,7 +561,7 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 
 // encodeTags performs base64 encoding on tags when needed.
 func encodeTags(tags []string) ([]string, error) {
-	keyTest := regexp.MustCompile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-]*$")
+	catTest := regexp.MustCompile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-]*$")
 	valTest := regexp.MustCompile("^[`+A-Za-z0-9!@#\\$%^&\"'\\/\\?\\._\\-:=]*$")
 	res := []string{}
 
@@ -584,7 +584,7 @@ func encodeTags(tags []string) ([]string, error) {
 			}
 		}
 
-		if !keyTest.MatchString(cat) {
+		if !catTest.MatchString(cat) {
 			cat = `b"` + base64.StdEncoding.EncodeToString([]byte(cat)) + `"`
 		}
 

--- a/tags.go
+++ b/tags.go
@@ -592,27 +592,29 @@ func encodeTags(tags []string) ([]string, error) {
 			return nil, fmt.Errorf("invalid tag passed: %v", tag)
 		}
 
-		if len(parts) > 1 {
-			val := parts[1]
-
-			if strings.HasPrefix(val, `b"`) && strings.HasSuffix(val, `"`) {
-				val = strings.TrimPrefix(strings.TrimSuffix(val, `"`), `b"`)
-
-				val, err := base64.StdEncoding.DecodeString(val)
-				if err != nil {
-					return nil, fmt.Errorf("invalid base64 tag value: %v %w",
-						val, err)
-				}
-			}
-
-			if !valTest.MatchString(val) {
-				val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
-			}
-
-			res = append(res, cat+":"+val)
-		} else {
+		if len(parts) < 2 {
 			res = append(res, cat+":")
+
+			continue
 		}
+
+		val := parts[1]
+
+		if strings.HasPrefix(val, `b"`) && strings.HasSuffix(val, `"`) {
+			val = strings.TrimPrefix(strings.TrimSuffix(val, `"`), `b"`)
+
+			val, err := base64.StdEncoding.DecodeString(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid base64 tag value: %v %w",
+					val, err)
+			}
+		}
+
+		if !valTest.MatchString(val) {
+			val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
+		}
+
+		res = append(res, cat+":"+val)
 	}
 
 	return res, nil

--- a/tags.go
+++ b/tags.go
@@ -571,9 +571,6 @@ func encodeTags(tags []string) ([]string, error) {
 		}
 
 		parts := strings.SplitN(tag, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid tag passed: %v", tag)
-		}
 
 		cat := parts[0]
 
@@ -591,23 +588,31 @@ func encodeTags(tags []string) ([]string, error) {
 			cat = `b"` + base64.StdEncoding.EncodeToString([]byte(cat)) + `"`
 		}
 
-		val := parts[1]
+		if cat == "" {
+			return nil, fmt.Errorf("invalid tag passed: %v", tag)
+		}
 
-		if strings.HasPrefix(val, `b"`) && strings.HasSuffix(val, `"`) {
-			val = strings.TrimPrefix(strings.TrimSuffix(val, `"`), `b"`)
+		if len(parts) > 1 {
+			val := parts[1]
 
-			val, err := base64.StdEncoding.DecodeString(val)
-			if err != nil {
-				return nil, fmt.Errorf("invalid base64 tag value: %v %w",
-					val, err)
+			if strings.HasPrefix(val, `b"`) && strings.HasSuffix(val, `"`) {
+				val = strings.TrimPrefix(strings.TrimSuffix(val, `"`), `b"`)
+
+				val, err := base64.StdEncoding.DecodeString(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid base64 tag value: %v %w",
+						val, err)
+				}
 			}
-		}
 
-		if !valTest.MatchString(val) {
-			val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
-		}
+			if !valTest.MatchString(val) {
+				val = `b"` + base64.StdEncoding.EncodeToString([]byte(val)) + `"`
+			}
 
-		res = append(res, cat+":"+val)
+			res = append(res, cat+":"+val)
+		} else {
+			res = append(res, cat+":")
+		}
 	}
 
 	return res, nil

--- a/tags_test.go
+++ b/tags_test.go
@@ -530,7 +530,7 @@ func TestUpdateCheckTags(t *testing.T) {
 	r, err := sc.UpdateCheckTags("11223344-5566-7788-9900-aabbccddeeff",
 		[]string{
 			"test:test",
-			"dGVzdA==:dGVzdA==",
+			"b\"dGVzdA==\":b\"dGVzdA==\"",
 		}, node)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
* fix: Corrects a bug in how check tag encoding is handled that was preventing UpdateCheckTags() from correctly updating check tags requiring base64 encoding.