### PR TITLE
CIRC-8800: Update DF4 types to include missing fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,5 +20,6 @@ linters:
       - godox
       - gomnd
       - nolintlint
+      - scopelint
       - tagliatelle
       - testpackage

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.11.0] - 2022-07-21
+
+* upd: Changes the DF4 data types to include fields that were missing for
+`head.error` and `head.warning`. Adds functionality to allow extracting typed
+data from DF4 data values.
+
 ## [v1.10.10] - 2022-06-15
 
 * upd: Changes the method used to stop retrying when contexts are canceled
@@ -376,6 +382,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.11.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.0
 [v1.10.10]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.10
 [v1.10.9]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.9
 [v1.10.8]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.8

--- a/caql.go
+++ b/caql.go
@@ -147,5 +147,7 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 		return nil, fmt.Errorf("unable to decode IRONdb response: %w", err)
 	}
 
+	r.Query = q.Query
+
 	return r, err
 }

--- a/df4.go
+++ b/df4.go
@@ -238,23 +238,29 @@ func (d *DF4Data) NullEmpty() {
 }
 
 // Numeric retrieves the data in this value as a slice of float64 values.
-func (dd *DF4Data) Numeric() []float64 {
+func (dd *DF4Data) Numeric() []*float64 {
 	if dd == nil {
 		return nil
 	}
 
-	r := make([]float64, len(*dd))
+	r := make([]*float64, len(*dd))
 
 	for i, v := range *dd {
 		switch tv := v.(type) {
 		case float64:
-			r[i] = tv
+			r[i] = &tv
 		case int64:
-			r[i] = float64(tv)
+			tvv := float64(tv)
+
+			r[i] = &tvv
 		case int:
-			r[i] = float64(tv)
+			tvv := float64(tv)
+
+			r[i] = &tvv
 		case float32:
-			r[i] = float64(tv)
+			tvv := float64(tv)
+
+			r[i] = &tvv
 		}
 	}
 
@@ -262,31 +268,27 @@ func (dd *DF4Data) Numeric() []float64 {
 }
 
 // Text retrieves the data in this value as a slice of string values.
-func (dd *DF4Data) Text() []string {
+func (dd *DF4Data) Text() []*string {
 	if dd == nil {
 		return nil
 	}
 
-	r := make([]string, len(*dd))
+	r := make([]*string, len(*dd))
 
 	for i, v := range *dd {
 		switch vv := v.(type) {
 		case string:
-			r[i] = vv
+			r[i] = &vv
 		case []interface{}:
 			if len(vv) > 0 {
 				if vvs, ok := vv[0].([]interface{}); ok && len(vvs) > 1 {
 					if s, ok := vvs[1].(string); ok {
-						r[i] = s
+						r[i] = &s
 
 						break
 					}
 				}
 			}
-
-			r[i] = ""
-		default:
-			r[i] = ""
 		}
 	}
 
@@ -295,31 +297,33 @@ func (dd *DF4Data) Text() []string {
 
 // Histogram retrieves the data in this value as a slice of map[string]int64
 // values.
-func (dd *DF4Data) Histogram() []map[string]int64 {
+func (dd *DF4Data) Histogram() []*map[string]int64 {
 	if dd == nil {
 		return nil
 	}
 
-	r := make([]map[string]int64, len(*dd))
+	r := make([]*map[string]int64, len(*dd))
 
 	for i, v := range *dd {
 		if m, ok := v.(map[string]interface{}); ok {
-			r[i] = make(map[string]int64, len(m))
+			mv := make(map[string]int64, len(m))
 
 			for k, iv := range m {
 				switch tv := iv.(type) {
 				case int64:
-					r[i][k] = tv
+					mv[k] = tv
 				case int:
-					r[i][k] = int64(tv)
+					mv[k] = int64(tv)
 				case float64:
-					r[i][k] = int64(tv)
+					mv[k] = int64(tv)
 				case float32:
-					r[i][k] = int64(tv)
+					mv[k] = int64(tv)
 				}
 			}
+
+			r[i] = &mv
 		} else if m, ok := v.(map[string]int64); ok {
-			r[i] = m
+			r[i] = &m
 		}
 	}
 

--- a/df4.go
+++ b/df4.go
@@ -12,7 +12,7 @@ import (
 type DF4Response struct {
 	Ver   string    `json:"version,omitempty"`
 	Head  DF4Head   `json:"head"`
-	Meta  []DF4Meta `json:"meta,omitempty"`
+	Meta  []DF4Meta `json:"meta"`
 	Data  []DF4Data `json:"data"`
 	Query string    `json:"-"`
 }

--- a/df4.go
+++ b/df4.go
@@ -3,16 +3,18 @@ package gosnowth
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 )
 
 // DF4Response values represent time series data in the DF4 format.
 type DF4Response struct {
-	Ver  string          `json:"version,omitempty"`
-	Head DF4Head         `json:"head"`
-	Meta []DF4Meta       `json:"meta,omitempty"`
-	Data [][]interface{} `json:"data,omitempty"`
+	Ver   string    `json:"version,omitempty"`
+	Head  DF4Head   `json:"head"`
+	Meta  []DF4Meta `json:"meta,omitempty"`
+	Data  []DF4Data `json:"data"`
+	Query string    `json:"-"`
 }
 
 // DF4Meta values contain information and metadata about the metrics in a DF4
@@ -26,24 +28,283 @@ type DF4Meta struct {
 // DF4Head values contain information about the time range of the data elements
 // in a DF4 time series data response.
 type DF4Head struct {
-	Count  int64 `json:"count"`
-	Start  int64 `json:"start"`
-	Period int64 `json:"period"`
+	Count   int64    `json:"count"`
+	Start   int64    `json:"start"`
+	Period  int64    `json:"period"`
+	Error   []string `json:"error,omitempty"`
+	Warning []string `json:"warning,omitempty"`
 	// TODO: Replace the Explain value with an actual typed schema when one
 	// becomes available.
 	Explain json.RawMessage `json:"explain,omitempty"`
 }
 
+// MarshalJSON encodes a DF4Head value into a JSON format byte slice.
+func (h *DF4Head) MarshalJSON() ([]byte, error) {
+	v := struct {
+		Count   int64           `json:"count"`
+		Start   int64           `json:"start"`
+		Period  int64           `json:"period"`
+		Error   json.RawMessage `json:"error,omitempty"`
+		Warning json.RawMessage `json:"warning,omitempty"`
+		Explain json.RawMessage `json:"explain,omitempty"`
+	}{
+		Count:   h.Count,
+		Start:   h.Start,
+		Period:  h.Period,
+		Explain: h.Explain,
+	}
+
+	if len(h.Error) == 1 {
+		b, err := json.Marshal(h.Error[0])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal df4 head error value into JSON data: %w",
+				err)
+		}
+
+		v.Error = b
+	} else if len(h.Error) > 1 {
+		b, err := json.Marshal(h.Error)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal df4 head error value into JSON data: %w",
+				err)
+		}
+
+		v.Error = b
+	}
+
+	if len(h.Warning) == 1 {
+		b, err := json.Marshal(h.Warning[0])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal df4 head warning value into JSON data: %w",
+				err)
+		}
+
+		v.Warning = b
+	} else if len(h.Warning) > 1 {
+		b, err := json.Marshal(h.Warning)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal df4 head warning value into JSON data: %w",
+				err)
+		}
+
+		v.Warning = b
+	}
+
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON decodes a DF4Head value from a JSON format byte slice.
+func (h *DF4Head) UnmarshalJSON(b []byte) error {
+	m := map[string]interface{}{}
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return fmt.Errorf(
+			"unable to unmarshal df4 head value from JSON data: %w", err)
+	}
+
+	for k, v := range m {
+		switch k {
+		case "count":
+			switch vt := v.(type) {
+			case float64:
+				h.Count = int64(vt)
+			case string:
+				i, err := strconv.ParseInt(vt, 10, 64)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to parse %s value from JSON data: %w",
+						k, err)
+				}
+
+				h.Count = i
+			default:
+				return fmt.Errorf("unable to parse %s value from JSON data", k)
+			}
+		case "start":
+			switch vt := v.(type) {
+			case float64:
+				h.Start = int64(vt)
+			case string:
+				i, err := strconv.ParseInt(vt, 10, 64)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to parse %s value from JSON data: %w",
+						k, err)
+				}
+
+				h.Start = i
+			default:
+				return fmt.Errorf("unable to parse %s value from JSON data", k)
+			}
+		case "period":
+			switch vt := v.(type) {
+			case float64:
+				h.Period = int64(vt)
+			case string:
+				i, err := strconv.ParseInt(vt, 10, 64)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to parse %s value from JSON data: %w",
+						k, err)
+				}
+
+				h.Period = i
+			default:
+				return fmt.Errorf("unable to parse %s value from JSON data", k)
+			}
+		case "error":
+			switch vt := v.(type) {
+			case string:
+				h.Error = []string{vt}
+			case []string:
+				h.Error = vt
+			case []interface{}:
+				if len(vt) > 0 {
+					ss := make([]string, len(vt))
+
+					for i, vs := range vt {
+						s, ok := vs.(string)
+						if !ok {
+							return fmt.Errorf(
+								"unable to parse %s value from JSON data", k)
+						}
+
+						ss[i] = s
+					}
+
+					h.Error = ss
+				}
+			default:
+				return fmt.Errorf("unable to parse %s value from JSON data", k)
+			}
+		case "warning":
+			switch vt := v.(type) {
+			case string:
+				h.Warning = []string{vt}
+			case []string:
+				h.Warning = vt
+			case []interface{}:
+				if len(vt) > 0 {
+					ss := make([]string, len(vt))
+
+					for i, vs := range vt {
+						s, ok := vs.(string)
+						if !ok {
+							return fmt.Errorf(
+								"unable to parse %s value from JSON data", k)
+						}
+
+						ss[i] = s
+					}
+
+					h.Warning = ss
+				}
+			default:
+				return fmt.Errorf("unable to parse %s value from JSON data", k)
+			}
+		case "explain":
+			b, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to parse %s value from JSON data: %w", k, err)
+			}
+
+			h.Explain = b
+		}
+	}
+
+	return nil
+}
+
+// DF4Data values contain slices of data points of DF4 format time series data.
+type DF4Data []interface{}
+
+// Numeric retrieves the data in this value as a slice of float64 values.
+func (dd *DF4Data) Numeric() []float64 {
+	if dd == nil {
+		return nil
+	}
+
+	r := make([]float64, len(*dd))
+	for i, v := range *dd {
+		switch tv := v.(type) {
+		case float64:
+			r[i] = tv
+		case int64:
+			r[i] = float64(tv)
+		case int:
+			r[i] = float64(tv)
+		case float32:
+			r[i] = float64(tv)
+		}
+	}
+
+	return r
+}
+
+// Text retrieves the data in this value as a slice of string values.
+func (dd *DF4Data) Text() []string {
+	if dd == nil {
+		return nil
+	}
+
+	r := make([]string, len(*dd))
+	for i, v := range *dd {
+		if vv, ok := v.(string); ok {
+			r[i] = vv
+		}
+	}
+
+	return r
+}
+
+// Histogram retrieves the data in this value as a slice of map[string]int64
+// values.
+func (dd *DF4Data) Histogram() []map[string]int64 {
+	if dd == nil {
+		return nil
+	}
+
+	r := make([]map[string]int64, len(*dd))
+	for i, v := range *dd {
+		if m, ok := v.(map[string]interface{}); ok {
+			r[i] = make(map[string]int64, len(m))
+			for k, iv := range m {
+				switch tv := iv.(type) {
+				case int64:
+					r[i][k] = tv
+				case int:
+					r[i][k] = int64(tv)
+				case float64:
+					r[i][k] = int64(tv)
+				case float32:
+					r[i][k] = int64(tv)
+				}
+			}
+		} else if m, ok := v.(map[string]int64); ok {
+			r[i] = m
+		}
+	}
+
+	return r
+}
+
 // Copy returns a deep copy of the base DF4 response.
 func (dr *DF4Response) Copy() *DF4Response {
 	b := &DF4Response{
-		Data: make([][]interface{}, len(dr.Data)),
+		Data: make([]DF4Data, len(dr.Data)),
 		Meta: make([]DF4Meta, len(dr.Meta)),
 		Ver:  dr.Ver,
 		Head: DF4Head{
 			Count:   dr.Head.Count,
 			Start:   dr.Head.Start,
 			Period:  dr.Head.Period,
+			Error:   dr.Head.Error,
+			Warning: dr.Head.Warning,
 			Explain: dr.Head.Explain,
 		},
 	}
@@ -51,7 +312,7 @@ func (dr *DF4Response) Copy() *DF4Response {
 	copy(b.Meta, dr.Meta)
 
 	for i, v := range dr.Data {
-		b.Data[i] = make([]interface{}, len(v))
+		b.Data[i] = make(DF4Data, len(v))
 		copy(b.Data[i], v)
 	}
 
@@ -64,37 +325,25 @@ func replaceInf(b []byte) []byte {
 	v := make([]byte, len(b))
 	copy(v, b)
 
-	v = bytes.ReplaceAll(v, []byte("+inf,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
-	v = bytes.ReplaceAll(v, []byte("+inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
-	v = bytes.ReplaceAll(v, []byte("+inf\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
-	v = bytes.ReplaceAll(v, []byte("-inf,"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+","))
-	v = bytes.ReplaceAll(v, []byte("-inf]"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"]"))
-	v = bytes.ReplaceAll(v, []byte("-inf\n"), []byte(
-		strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)+"\n"))
-	v = bytes.ReplaceAll(v, []byte("inf,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
-	v = bytes.ReplaceAll(v, []byte("inf]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
-	v = bytes.ReplaceAll(v, []byte("inf\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
+	maxFloat := strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)
+	negMaxFloat := strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64)
 
-	v = bytes.ReplaceAll(v, []byte("NaN,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
-	v = bytes.ReplaceAll(v, []byte("NaN]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
-	v = bytes.ReplaceAll(v, []byte("NaN\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
-	v = bytes.ReplaceAll(v, []byte("nan,"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+","))
-	v = bytes.ReplaceAll(v, []byte("nan]"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"]"))
-	v = bytes.ReplaceAll(v, []byte("nan\n"), []byte(
-		strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)+"\n"))
+	v = bytes.ReplaceAll(v, []byte("+inf,"), []byte(maxFloat+","))
+	v = bytes.ReplaceAll(v, []byte("+inf]"), []byte(maxFloat+"]"))
+	v = bytes.ReplaceAll(v, []byte("+inf\n"), []byte(maxFloat+"\n"))
+	v = bytes.ReplaceAll(v, []byte("-inf,"), []byte(negMaxFloat+","))
+	v = bytes.ReplaceAll(v, []byte("-inf]"), []byte(negMaxFloat+"]"))
+	v = bytes.ReplaceAll(v, []byte("-inf\n"), []byte(negMaxFloat+"\n"))
+	v = bytes.ReplaceAll(v, []byte("inf,"), []byte(maxFloat+","))
+	v = bytes.ReplaceAll(v, []byte("inf]"), []byte(maxFloat+"]"))
+	v = bytes.ReplaceAll(v, []byte("inf\n"), []byte(maxFloat+"\n"))
+
+	v = bytes.ReplaceAll(v, []byte("NaN,"), []byte(maxFloat+","))
+	v = bytes.ReplaceAll(v, []byte("NaN]"), []byte(maxFloat+"]"))
+	v = bytes.ReplaceAll(v, []byte("NaN\n"), []byte(maxFloat+"\n"))
+	v = bytes.ReplaceAll(v, []byte("nan,"), []byte(maxFloat+","))
+	v = bytes.ReplaceAll(v, []byte("nan]"), []byte(maxFloat+"]"))
+	v = bytes.ReplaceAll(v, []byte("nan\n"), []byte(maxFloat+"\n"))
 
 	return v
 }

--- a/df4.go
+++ b/df4.go
@@ -98,6 +98,7 @@ func (h *DF4Head) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes a DF4Head value from a JSON format byte slice.
+//nolint gocyclo
 func (h *DF4Head) UnmarshalJSON(b []byte) error {
 	m := map[string]interface{}{}
 
@@ -230,6 +231,7 @@ func (dd *DF4Data) Numeric() []float64 {
 	}
 
 	r := make([]float64, len(*dd))
+
 	for i, v := range *dd {
 		switch tv := v.(type) {
 		case float64:
@@ -253,6 +255,7 @@ func (dd *DF4Data) Text() []string {
 	}
 
 	r := make([]string, len(*dd))
+
 	for i, v := range *dd {
 		if vv, ok := v.(string); ok {
 			r[i] = vv
@@ -270,9 +273,11 @@ func (dd *DF4Data) Histogram() []map[string]int64 {
 	}
 
 	r := make([]map[string]int64, len(*dd))
+
 	for i, v := range *dd {
 		if m, ok := v.(map[string]interface{}); ok {
 			r[i] = make(map[string]int64, len(m))
+
 			for k, iv := range m {
 				switch tv := iv.(type) {
 				case int64:

--- a/df4_test.go
+++ b/df4_test.go
@@ -13,6 +13,8 @@ const testDF4Response = `{
 		"count": 3,
 		"start": 0,
 		"period": 300,
+		"error": ["test", "test"],
+		"warning": "test",
 		"explain":{
 			"info":{
 				"putype":["none","number"]
@@ -22,10 +24,26 @@ const testDF4Response = `{
 	"meta": [
 		{
 			"kind": "numeric",
-			"label": "test",
+			"label": "test_numeric",
 			"tags": [
 				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
-				"__name:test"
+				"__name:test_numeric"
+			]
+		},
+		{
+			"kind": "text",
+			"label": "test_text",
+			"tags": [
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test_text"
+			]
+		},
+		{
+			"kind": "histogram",
+			"label": "test_histogram",
+			"tags": [
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test_histogram"
 			]
 		}
 	],
@@ -34,6 +52,16 @@ const testDF4Response = `{
 			1,
 			2,
 			3
+		],
+		[
+			"test1",
+			"test2",
+			"test3"
+		],
+		[
+			{"+12e-004": 1},
+			{"+12e-004": 1},
+			{"+12e-004": 1}
 		]
 	]
 }`
@@ -72,20 +100,44 @@ func TestMarshalDF4Response(t *testing.T) {
 	t.Parallel()
 
 	v := &DF4Response{
-		Data: [][]interface{}{{1, 2, 3}},
+		Data: []DF4Data{
+			{1, 2, 3},
+			{"test1", "test2", "test3"},
+			{
+				map[string]int64{"+12e-004": 1},
+				map[string]int64{"+12e-004": 1},
+				map[string]int64{"+12e-004": 1},
+			},
+		},
 		Meta: []DF4Meta{{
 			Tags: []string{
 				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
-				"__name:test",
+				"__name:test_numeric",
 			},
-			Label: "test",
+			Label: "test_numeric",
 			Kind:  "numeric",
+		}, {
+			Tags: []string{
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test_text",
+			},
+			Label: "test_text",
+			Kind:  "text",
+		}, {
+			Tags: []string{
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test_histogram",
+			},
+			Label: "test_histogram",
+			Kind:  "histogram",
 		}},
 		Ver: "DF4",
 		Head: DF4Head{
-			Count:  3,
-			Start:  0,
-			Period: 300,
+			Count:   3,
+			Start:   0,
+			Period:  300,
+			Error:   []string{"test", "test"},
+			Warning: []string{"test"},
 			Explain: json.RawMessage([]byte(
 				`{"info":{"putype":["none","number"]}}`)),
 		},
@@ -104,7 +156,7 @@ func TestMarshalDF4Response(t *testing.T) {
 	}
 }
 
-func TestUnmarshalDF4Timeseries(t *testing.T) {
+func TestUnmarshalDF4Response(t *testing.T) {
 	t.Parallel()
 
 	var v *DF4Response
@@ -114,23 +166,81 @@ func TestUnmarshalDF4Timeseries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(v.Data) != 1 {
-		t.Fatalf(`Expected length: 1. got %d`, len(v.Data))
+	if len(v.Head.Error) != 2 {
+		t.Fatalf("Expected length: 2, got: %v", len(v.Head.Error))
+	}
+
+	if len(v.Head.Warning) != 1 {
+		t.Fatalf("Expected length: 1, got: %v", len(v.Head.Warning))
+	}
+
+	if v.Head.Warning[0] != "test" {
+		t.Errorf("Expected warning: test, got: %v", v.Head.Warning)
+	}
+
+	if len(v.Data) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(v.Data))
 	}
 
 	if v.Data[0][1] != 2.0 {
-		t.Errorf(`Expected value: 2.0. got %f`, v.Data[1][1])
+		t.Errorf("Expected value: 2.0, got: %v", v.Data[1][1])
 	}
 
 	if v.Head.Start != 0 {
-		t.Errorf(`Expected time start: 0. got %d`, v.Head.Start)
+		t.Errorf("Expected time start: 0, got: %v", v.Head.Start)
 	}
 
 	if v.Head.Period != 300 {
-		t.Errorf(`Expected time period: 300. got %d`, v.Head.Period)
+		t.Errorf("Expected time period: 300, got: %v", v.Head.Period)
 	}
 
-	if len(v.Head.Explain) != 53 {
-		t.Errorf("Expected length explain: 53, got: %v", len(v.Head.Explain))
+	exp := `{"info":{"putype":["none","number"]}}`
+	if string(v.Head.Explain) != exp {
+		t.Errorf("Expected explain: %v, got: %v", exp, string(v.Head.Explain))
+	}
+}
+
+func TestDF4Data(t *testing.T) {
+	t.Parallel()
+
+	var v *DF4Response
+
+	if err := json.NewDecoder(bytes.NewBufferString(
+		testDF4Response)).Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v.Data) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(v.Data))
+	}
+
+	num := v.Data[0].Numeric()
+
+	if len(num) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(num))
+	}
+
+	if num[1] != 2.0 {
+		t.Errorf("Expected value: 2.0, got: %v", num[1])
+	}
+
+	text := v.Data[1].Text()
+
+	if len(text) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(text))
+	}
+
+	if text[1] != "test2" {
+		t.Errorf("Expected value: test2, got: %v", text[1])
+	}
+
+	hist := v.Data[2].Histogram()
+
+	if len(hist) != 3 {
+		t.Fatalf("Expected length: 3, got: %v", len(hist))
+	}
+
+	if hist[1]["+12e-004"] != 1 {
+		t.Errorf("Expected value: 1, got: %v", hist[1]["+12e-004"])
 	}
 }

--- a/df4_test.go
+++ b/df4_test.go
@@ -54,9 +54,24 @@ const testDF4Response = `{
 			3
 		],
 		[
-			"test1",
-			"test2",
-			"test3"
+			[
+				[
+					6866,
+					"test1"
+				]
+			],
+			[
+				[
+					6866,
+					"test2"
+				]
+			],
+			[
+				[
+					6866,
+					"test3"
+				]
+			]
 		],
 		[
 			{"+12e-004": 1},
@@ -102,7 +117,11 @@ func TestMarshalDF4Response(t *testing.T) {
 	v := &DF4Response{
 		Data: []DF4Data{
 			{1, 2, 3},
-			{"test1", "test2", "test3"},
+			{
+				[][]interface{}{{6866, "test1"}},
+				[][]interface{}{{6866, "test2"}},
+				[][]interface{}{{6866, "test3"}},
+			},
 			{
 				map[string]int64{"+12e-004": 1},
 				map[string]int64{"+12e-004": 1},
@@ -242,5 +261,64 @@ func TestDF4Data(t *testing.T) {
 
 	if hist[1]["+12e-004"] != 1 {
 		t.Errorf("Expected value: 1, got: %v", hist[1]["+12e-004"])
+	}
+}
+
+const testDF4ResponseText = `{
+	"version": "DF4",
+	"head": {
+		"count": 3,
+		"start": 0,
+		"period": 300
+	},
+	"meta": [
+		{
+			"kind": "text",
+			"label": "test_text",
+			"tags": [
+				"__check_uuid:11223344-5566-7788-9900-aabbccddeeff",
+				"__name:test_text"
+			]
+		}
+	],
+	"data": [
+		[
+			[
+				[
+					6866,
+					"test1"
+				]
+			],
+			[],
+			[
+				[
+					6866,
+					"test3"
+				]
+			]
+		]
+	]
+}`
+
+func TestDF4DataNullEmpty(t *testing.T) {
+	t.Parallel()
+
+	var v *DF4Response
+
+	if err := json.NewDecoder(bytes.NewBufferString(
+		testDF4ResponseText)).Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(v.Data) != 1 {
+		t.Fatalf("Expected length: 1, got: %v", len(v.Data))
+	}
+
+	for _, dv := range v.Data {
+		dv.NullEmpty()
+	}
+
+	if v.Data[0][1] != nil {
+		t.Errorf("Expected value: nil, got: %v", v.Data[0][1])
 	}
 }


### PR DESCRIPTION
* upd: Changes the DF4 data types to include fields that were missing for `head.error` and `head.warning`. Adds functionality to allow extracting typed data from DF4 data values.