### PR TITLE
CIRC-8973: Remove ioutil package, update go build version, additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,12 +14,10 @@ linters:
     disable:
       - dupl
       - funlen
-      - gci
       - gocognit
       - goconst
-      - godox
       - gomnd
-      - nolintlint
+      - ifshort
       - scopelint
       - tagliatelle
       - testpackage

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.11.2] - 2022-08-18
+
+* upd: Removes all use of the deprecated ioutil package, includes some code
+cleanup and adds additional linters.
+* upd: Updates the minumum go build version to 1.17.
+
 ## [v1.11.1] - 2022-07-29
 
 * upd: Simplifies to gosnowth.Config type to no longer implement unneeded
@@ -399,6 +405,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.11.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.2
 [v1.11.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.1
 [v1.11.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.0
 [v1.10.11]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.10.11

--- a/activity_test.go
+++ b/activity_test.go
@@ -2,7 +2,7 @@ package gosnowth
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -29,26 +29,26 @@ func TestRebuildActivity(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/surrogate/activity_rebuild") {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error("Unable to read request body")
 			}
 
 			if string(b) == "[]\n" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, "misdirected": 0, "errors": 0 }`))
 
 				return
 			}
 
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("invalid request body"))
 
 			return
 		}
 
 		t.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()

--- a/caql.go
+++ b/caql.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
@@ -111,7 +111,7 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 		return nil, err
 	}
 
-	bBuf, err := ioutil.ReadAll(qBuf)
+	bBuf, err := io.ReadAll(qBuf)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read request body buffer: %w", err)
 	}
@@ -136,7 +136,7 @@ func (sc *SnowthClient) GetCAQLQueryContext(ctx context.Context, q *CAQLQuery,
 		return nil, err
 	}
 
-	rb, err := ioutil.ReadAll(body)
+	rb, err := io.ReadAll(body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read IRONdb response body: %w", err)
 	}

--- a/caql_test.go
+++ b/caql_test.go
@@ -1,7 +1,7 @@
 package gosnowth
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -56,7 +56,7 @@ func TestGetCAQLQuery(t *testing.T) {
 
 		if r.Method == "POST" && strings.HasPrefix(r.RequestURI,
 			"/extension/lua/public/caql_v1") {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(testCAQLError))
@@ -72,7 +72,7 @@ func TestGetCAQLQuery(t *testing.T) {
 			}
 
 			if strings.Contains(string(b), "histograms") {
-				w.WriteHeader(502)
+				w.WriteHeader(http.StatusBadGateway)
 				_, _ = w.Write([]byte(testCAQLError))
 
 				return

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -92,30 +91,6 @@ func NewConfig(servers ...string) *Config {
 }
 
 // SnowthClient values provide client functionality for accessing IRONdb.
-// Operations for the client can be broken down into 6 major sections:
-//		1.) State and Topology
-// Within the state and topology APIs, there are several useful apis, including
-// apis to retrieve Node state, Node gossip information, topology information,
-// and topo ring information.  Each of these operations is implemented as a method
-// on this client.
-//		2.) Rebalancing APIs
-// In order to add or remove nodes within an IRONdb cluster you will have to use
-// the rebalancing APIs.  Implemented within this package you will be able to
-// load a new topology, rebalance nodes to the new topology, as well as check
-// load state information and abort a topology change.
-//		3.) Data Retrieval APIs
-// IRONdb houses data, and the data retrieval APIs allow for accessing of that
-// stored data.  Data types implemented include NNT, Text, and Histogram data
-// element types.
-//		4.) Data Submission APIs
-// IRONdb houses data, to which you can use to submit data to the cluster.  Data
-// types supported include the same for the retrieval APIs, NNT, Text and
-// Histogram data types.
-//		5.) Data Deletion APIs
-// Data sometimes needs to be deleted, and that is performed with the data
-// deletion APIs.  This client implements the data deletion apis to remove data
-// from the nodes.
-//		6.) Lua Extensions APIs
 type SnowthClient struct {
 	sync.RWMutex
 	c httpClient
@@ -825,7 +800,7 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 	var err error
 
 	if body != nil {
-		bBody, err = ioutil.ReadAll(body)
+		bBody, err = io.ReadAll(body)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to read request body: %w", err)
 		}
@@ -1081,7 +1056,7 @@ func (sc *SnowthClient) do(ctx context.Context,
 		_ = resp.Body.Close()
 	}()
 
-	res, err := ioutil.ReadAll(resp.Body)
+	res, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, resp.StatusCode,
 			fmt.Errorf("unable to read response body: %w", err)

--- a/common_test.go
+++ b/common_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -142,7 +142,7 @@ func TestEncodeXML(t *testing.T) {
 		t.Error("error encountered encoding: ", err)
 	}
 
-	b, _ := ioutil.ReadAll(reader)
+	b, _ := io.ReadAll(reader)
 	if !strings.Contains(string(b), "somethingelse") {
 		t.Error("Should contain somethingelse")
 	}

--- a/df4.go
+++ b/df4.go
@@ -28,13 +28,11 @@ type DF4Meta struct {
 // DF4Head values contain information about the time range of the data elements
 // in a DF4 time series data response.
 type DF4Head struct {
-	Count   int64    `json:"count"`
-	Start   int64    `json:"start"`
-	Period  int64    `json:"period"`
-	Error   []string `json:"error,omitempty"`
-	Warning []string `json:"warning,omitempty"`
-	// TODO: Replace the Explain value with an actual typed schema when one
-	// becomes available.
+	Count   int64           `json:"count"`
+	Start   int64           `json:"start"`
+	Period  int64           `json:"period"`
+	Error   []string        `json:"error,omitempty"`
+	Warning []string        `json:"warning,omitempty"`
 	Explain json.RawMessage `json:"explain,omitempty"`
 }
 
@@ -98,8 +96,7 @@ func (h *DF4Head) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON decodes a DF4Head value from a JSON format byte slice.
-//nolint gocyclo
-func (h *DF4Head) UnmarshalJSON(b []byte) error {
+func (h *DF4Head) UnmarshalJSON(b []byte) error { //nolint:gocyclo
 	m := map[string]interface{}{}
 
 	if err := json.Unmarshal(b, &m); err != nil {

--- a/df4_test.go
+++ b/df4_test.go
@@ -76,11 +76,11 @@ const testDF4Response = `{
 	]
 }`
 
-//nolint shortif
 func TestDF4ResponseCopy(t *testing.T) {
 	t.Parallel()
 
 	var v *DF4Response
+
 	err := json.NewDecoder(bytes.NewBufferString(testDF4Response)).Decode(&v)
 	if err != nil {
 		t.Fatal(err)
@@ -88,6 +88,7 @@ func TestDF4ResponseCopy(t *testing.T) {
 
 	b := v.Copy()
 	buf := &bytes.Buffer{}
+
 	err = json.NewEncoder(buf).Encode(&b)
 	if err != nil {
 		t.Fatal(err)
@@ -95,6 +96,7 @@ func TestDF4ResponseCopy(t *testing.T) {
 
 	s1 := buf.String()
 	buf = &bytes.Buffer{}
+
 	err = json.NewEncoder(buf).Encode(&v)
 	if err != nil {
 		t.Fatal(err)

--- a/examples/retrieval.go
+++ b/examples/retrieval.go
@@ -7,9 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/circonus-labs/gosnowth"
+	"github.com/google/uuid"
 )
 
 // ExampleReadNNT demonstrates how to read NNT values from a given snowth node.

--- a/examples/submission.go
+++ b/examples/submission.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/circonus-labs/gosnowth"
+	"github.com/circonus-labs/gosnowth/fb/noit"
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/google/uuid"
 	"github.com/openhistogram/circonusllhist"
-
-	"github.com/circonus-labs/gosnowth"
-	"github.com/circonus-labs/gosnowth/fb/noit"
 )
 
 // ExampleSubmitText demonstrates how to submit a text metric to a node.

--- a/fetch.go
+++ b/fetch.go
@@ -5,14 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
 
-	flatbuffers "github.com/google/flatbuffers/go"
-
 	"github.com/circonus-labs/gosnowth/fb/fetch"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 // FetchStream values represent queries for individual data streams in an
@@ -165,7 +164,7 @@ func (sc *SnowthClient) FetchValuesContext(ctx context.Context,
 		return nil, err
 	}
 
-	rb, err := ioutil.ReadAll(body)
+	rb, err := io.ReadAll(body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read IRONdb response body: %w", err)
 	}
@@ -212,7 +211,7 @@ func (sc *SnowthClient) FetchValuesFbContext(ctx context.Context,
 		return nil, err
 	}
 
-	df4Buf, err := ioutil.ReadAll(body)
+	df4Buf, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/circonus-labs/gosnowth
 
-go 1.14
+go 1.17
 
 require (
 	github.com/google/flatbuffers v2.0.6+incompatible

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -170,14 +170,14 @@ func TestWriteHistogram(t *testing.T) {
 		if r.RequestURI == "/histogram/write" {
 			rb := []HistogramData{}
 			if err := json.NewDecoder(r.Body).Decode(&rb); err != nil {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 				t.Error("Unable to decode JSON data")
 
 				return
 			}
 
 			if len(rb) < 1 {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 				t.Error("Invalid request")
 
 				return
@@ -185,7 +185,7 @@ func TestWriteHistogram(t *testing.T) {
 
 			exp := "ae0f7f90-2a6b-481c-9cf5-21a31837020e"
 			if rb[0].ID != exp {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 				t.Errorf("Expected UUID: %v, got: %v", exp, rb[0].ID)
 
 				return

--- a/lua.go
+++ b/lua.go
@@ -33,18 +33,20 @@ type LuaExtension struct {
 type LuaExtensions map[string]*LuaExtension
 
 // UnmarshalJSON decodes a byte slice of JSON data into a LuaExtensions map.
-//nolint gocyclo
-func (le *LuaExtensions) UnmarshalJSON(b []byte) error {
+func (le *LuaExtensions) UnmarshalJSON(b []byte) error { //nolint:gocyclo
 	r := map[string]interface{}{}
+
 	err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&r)
 	if err != nil {
 		return err
 	}
 
 	*le = make(map[string]*LuaExtension, len(r))
+
 	for k, ext := range r {
 		(*le)[k] = &LuaExtension{Name: k}
-		if v, ok := ext.(map[string]interface{}); ok {
+
+		if v, ok := ext.(map[string]interface{}); ok { //nolint:nestif
 			for key, val := range v {
 				switch key {
 				case "documentation":
@@ -63,9 +65,11 @@ func (le *LuaExtensions) UnmarshalJSON(b []byte) error {
 					if value, ok := val.(map[string]interface{}); ok {
 						(*le)[k].Params = make(map[string]*ExtensionParam,
 							len(value))
+
 						for pk, pv := range value {
 							if pMap, ok := pv.(map[string]interface{}); ok {
 								(*le)[k].Params[pk] = &ExtensionParam{Name: pk}
+
 								for pKey, pVal := range pMap {
 									switch pKey {
 									case "type":
@@ -85,6 +89,7 @@ func (le *LuaExtensions) UnmarshalJSON(b []byte) error {
 									case "alias_list":
 										if pV, ok := pVal.([]interface{}); ok {
 											(*le)[k].Params[pk].AliasList = make([]string, len(pV))
+
 											for n, iV := range pV {
 												if itV, ok := iV.(string); ok {
 													(*le)[k].Params[pk].

--- a/metric.go
+++ b/metric.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -166,7 +165,7 @@ func (ms *metricScanner) scanMetricName() (scanToken, string, error) {
 
 	for {
 		ch := ms.read()
-		if ch == '|' { //nolint nestif
+		if ch == '|' { //nolint:nestif
 			if err := ms.unread(); err != nil {
 				return tokenIllegal, "", fmt.Errorf(
 					"unable to unread to scan buffer: %w", err)
@@ -225,7 +224,7 @@ loop:
 					"unable to write to tag name canonical buffer: %w", err)
 			}
 		case '\\':
-			if quoted { //nolint nestif
+			if quoted { //nolint:nestif
 				ch2 := ms.read()
 				if ch2 == '"' || ch2 == '\\' {
 					if _, err := buf.WriteRune(ch2); err != nil {
@@ -314,12 +313,11 @@ loop:
 }
 
 // scanTagValue attempts to read a tag value token from the scan buffer.
-//nolint gocyclo
-func (ms *metricScanner) scanTagValue(
+func (ms *metricScanner) scanTagValue( //nolint:gocyclo
 	tt tagType,
 ) (scanToken, string, string, error) {
-	var buf bytes.Buffer
-	var can bytes.Buffer
+	var buf, can bytes.Buffer
+
 	quoted := false
 
 loop:
@@ -339,7 +337,7 @@ loop:
 					"unable to write to canonical tag name buffer: %w", err)
 			}
 		case '\\':
-			if quoted {
+			if quoted { //nolint:nestif
 				ch2 := ms.read()
 				if ch2 == '"' || ch2 == '\\' {
 					if _, err := buf.WriteRune(ch2); err != nil {
@@ -481,7 +479,7 @@ func (mp *MetricParser) parseTagSet(tt tagType) (string, []Tag, error) {
 			strings.HasSuffix(tag.Category, `"`) {
 			val := strings.Trim(tag.Category[1:], `"`)
 
-			b, err := ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding,
+			b, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding,
 				bytes.NewBufferString(val)))
 			if err != nil {
 				return "", nil, fmt.Errorf(
@@ -521,7 +519,7 @@ func (mp *MetricParser) parseTagSet(tt tagType) (string, []Tag, error) {
 			strings.HasSuffix(tag.Value, `"`) {
 			val := strings.Trim(tag.Value[1:], `"`)
 
-			b, err := ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding,
+			b, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding,
 				bytes.NewBufferString(val)))
 			if err != nil {
 				return "", nil, fmt.Errorf(

--- a/nnt_test.go
+++ b/nnt_test.go
@@ -163,7 +163,7 @@ func TestNNTReadWrite(t *testing.T) {
 
 		u = "/write/nnt"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			return
 		}

--- a/nntbs.go
+++ b/nntbs.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	flatbuffers "github.com/google/flatbuffers/go"
-
 	"github.com/circonus-labs/gosnowth/fb/nntbs"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 const metricSourceGraphite = 0x2

--- a/nntbs_test.go
+++ b/nntbs_test.go
@@ -1,16 +1,15 @@
 package gosnowth
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
-	flatbuffers "github.com/google/flatbuffers/go"
-
 	"github.com/circonus-labs/gosnowth/fb/nntbs"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 func TestWriteNNTBSFlatbuffer(t *testing.T) {
@@ -32,19 +31,19 @@ func TestWriteNNTBSFlatbuffer(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/nntbs") {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error("Unable to read request body")
 			}
 
 			if string(b)[4:8] == "CINN" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ "records": 1, "updated": 1, "misdirected": 0, "errors": 0 }`))
 
 				return
 			}
 
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("invalid request body:"))
 			_, _ = w.Write(b)
 
@@ -52,7 +51,7 @@ func TestWriteNNTBSFlatbuffer(t *testing.T) {
 		}
 
 		t.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -163,7 +163,7 @@ func TestNumericReadWrite(t *testing.T) {
 
 		u = "/write/nnt"
 		if strings.HasPrefix(r.RequestURI, u) {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			return
 		}

--- a/raw.go
+++ b/raw.go
@@ -12,9 +12,8 @@ import (
 	"strconv"
 	"time"
 
-	flatbuffers "github.com/google/flatbuffers/go"
-
 	"github.com/circonus-labs/gosnowth/fb/noit"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 // MetriclistFlatbufferContentType is the content type header for flatbuffer

--- a/raw_test.go
+++ b/raw_test.go
@@ -3,7 +3,7 @@ package gosnowth
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,9 +12,8 @@ import (
 	"testing"
 	"time"
 
-	flatbuffers "github.com/google/flatbuffers/go"
-
 	"github.com/circonus-labs/gosnowth/fb/noit"
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 func TestWriteRaw(t *testing.T) {
@@ -36,27 +35,27 @@ func TestWriteRaw(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/raw") {
-			buf, err := ioutil.ReadAll(r.Body)
+			buf, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error("Unable to read request body")
 			}
 
 			if string(buf) == "test" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, ` +
 					`"misdirected": 0, "errors": 0 }`))
 
 				return
 			}
 
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("invalid request body"))
 
 			return
 		}
 
 		t.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()
@@ -121,7 +120,7 @@ func TestReadRawNumericValues(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/raw") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(
 				`[[1529509063064,0],[1529509122985,0],[1529509183764,0]]`))
 
@@ -129,7 +128,7 @@ func TestReadRawNumericValues(t *testing.T) {
 		}
 
 		t.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()
@@ -176,27 +175,27 @@ func TestWriteRawMetricList(t *testing.T) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/raw") {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Error("Unable to read request body")
 			}
 
 			if string(b)[4:8] == "CIML" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, ` +
 					`"misdirected": 0, "errors": 0 }`))
 
 				return
 			}
 
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("invalid request body"))
 
 			return
 		}
 
 		t.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()
@@ -360,27 +359,27 @@ func BenchmarkWriteRawMetricListLocal(b *testing.B) {
 		}
 
 		if strings.HasPrefix(r.RequestURI, "/raw") {
-			buf, err := ioutil.ReadAll(r.Body)
+			buf, err := io.ReadAll(r.Body)
 			if err != nil {
 				b.Error("Unable to read request body")
 			}
 
 			if string(buf)[4:8] == "CIML" {
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ "records": 0, "updated": 0, ` +
 					`"misdirected": 0, "errors": 0 }`))
 
 				return
 			}
 
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("invalid request body"))
 
 			return
 		}
 
 		b.Errorf("Unexpected request: %v", r)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()

--- a/tags_test.go
+++ b/tags_test.go
@@ -99,8 +99,7 @@ func TestFindTagsJSON(t *testing.T) {
 	}
 }
 
-//nolint: gocyclo
-func TestFindTags(t *testing.T) {
+func TestFindTags(t *testing.T) { //nolint:gocyclo
 	t.Parallel()
 
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,

--- a/text_test.go
+++ b/text_test.go
@@ -46,7 +46,7 @@ func TestReadTextValuesFindMetricNode(t *testing.T) {
 			return
 		}
 
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()
@@ -100,7 +100,7 @@ func TestReadTextValues(t *testing.T) {
 			return
 		}
 
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()
@@ -156,12 +156,12 @@ func TestWriteText(t *testing.T) {
 
 		if strings.HasPrefix(r.RequestURI,
 			"/write/text") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			return
 		}
 
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()

--- a/topology.go
+++ b/topology.go
@@ -129,20 +129,21 @@ func (topo *Topology) compile() error {
 
 	// This matches the horrible backware compatibility requirements in the
 	// C version.
-	//nolint nestif
-	if topo.WriteCopies != 2 {
+	if topo.WriteCopies != 2 { //nolint:nestif
 		if _, err := hash.Write(bytes.Repeat([]byte{0}, 38)); err != nil {
 			return fmt.Errorf("unable to write hash: %w", err)
 		}
 
 		netshort := make([]byte, 2)
 		binary.BigEndian.PutUint16(netshort, uint16(topo.WriteCopies))
+
 		if _, err := hash.Write(netshort); err != nil {
 			return fmt.Errorf("unable to write hash: %w", err)
 		}
 
 		if topo.useSide {
 			binary.BigEndian.PutUint16(netshort, 0)
+
 			if _, err := hash.Write(netshort); err != nil {
 				return fmt.Errorf("unable to write hash: %w", err)
 			}

--- a/topology_test.go
+++ b/topology_test.go
@@ -233,19 +233,19 @@ func TestTopology(t *testing.T) {
 
 		if strings.HasPrefix(r.RequestURI,
 			"/topology/test") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			return
 		}
 
 		if strings.HasPrefix(r.RequestURI,
 			"/activate/test") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 
 			return
 		}
 
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 
 	defer ms.Close()


### PR DESCRIPTION
* upd: Removes all use of the deprecated ioutil package, includes some code cleanup and adds additional linters.
* upd: Disables the deprecated ifshort linter.
* upd: Updates the minumum go build version to 1.17.
* upd: Replaces some number constants with their named constants from the standard library.