### PR TITLE
CIRC-9720: Make sure nodes are tested active and populated with stats upon discovery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
       - goconst
       - gomnd
       - ifshort
+      - nosnakecase
       - scopelint
       - tagliatelle
       - testpackage

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.11.4] - 2023-01-26
+
+* fix: Ensures that snowth nodes loaded by the topology discovery process are
+properly populated with all stats information, and are correctly added as
+inactive servers if they are not responding to network requests.
+
 ## [v1.11.3] - 2022-11-30
 
 * upd: Updates the WatchAndUpdate() functionality of SnowthClient to correctly
@@ -410,6 +416,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.11.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.4
 [v1.11.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.3
 [v1.11.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.2
 [v1.11.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.1

--- a/client.go
+++ b/client.go
@@ -553,7 +553,8 @@ func (sc *SnowthClient) discoverNodes(ctx context.Context) error {
 // populateNodeInfo populates an existing node with details from the topology.
 // If a node doesn't exist, it will be added to the list of active nodes.
 func (sc *SnowthClient) populateNodeInfo(ctx context.Context, hash string,
-	topology TopologyNode) {
+	topology TopologyNode,
+) {
 	sc.Lock()
 
 	found := false


### PR DESCRIPTION
* fix: Ensures that snowth nodes loaded by the topology discovery process are properly populated with all stats information, and are correctly added as inactive servers if they are not responding to network requests.