### PR TITLE
CIRC-9833: Improve placement of trace ID in debug log entries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.12.2] - 2023-02-17
+
+* upd: Improve trace ID placement in log entries to ensure it is not truncated
+by request bodies in some debug logs.
+
 ## [v1.12.1] - 2023-02-15
 
 * upd: Removes the WatchFunc functionality as this is not used anymore.
@@ -428,6 +433,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.12.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.2
 [v1.12.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.1
 [v1.12.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.0
 [v1.11.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.11.4

--- a/client.go
+++ b/client.go
@@ -841,9 +841,9 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 			surl := sc.getURL(sn, url)
 
 			sc.LogDebugf("gosnowth %s request "+
-				"[retry: %d, connRetry: %d]: %s %s %s traceID: %s",
-				reqMsg, r, (cr - connRetries), method, surl,
-				string(bBody), traceID)
+				"[traceID: %s, retry: %d, connRetry: %d]: %s %s %s",
+				reqMsg, traceID, r, (cr - connRetries), method, surl,
+				string(bBody))
 
 			start := time.Now()
 
@@ -851,9 +851,9 @@ func (sc *SnowthClient) DoRequestContext(ctx context.Context, node *SnowthNode,
 				bytes.NewBuffer(bBody), headers, traceID)
 
 			sc.LogDebugf("gosnowth request complete "+
-				"[retry: %d, connRetry: %d]: %s %s latency: %+v traceID: %s",
-				r, (cr - connRetries), method, surl,
-				time.Since(start), traceID)
+				"[traceID: %s, retry: %d, connRetry: %d]: %s %s latency: %+v",
+				traceID, r, (cr - connRetries), method, surl,
+				time.Since(start))
 
 			if err == nil {
 				return bdy, hdr, nil


### PR DESCRIPTION
* upd: Improve trace ID placement in log entries to ensure it is not truncated by request bodies in some debug logs.