### PR TITLE
CIRC-9833: Add all tags every time UpdateCheckTags is called

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.12.3] - 2023-02-17
+
+* upd: Changes the mechanism of updating check tags to mitigate a race condition
+that can occur if check tags are being rapidly changed. Always attempts to add
+the full set of check tags being submitted rather than only the ones it snowth
+thinks do not already exist.
+
 ## [v1.12.2] - 2023-02-17
 
 * upd: Improve trace ID placement in log entries to ensure it is not truncated
@@ -433,6 +440,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.12.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.3
 [v1.12.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.2
 [v1.12.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.1
 [v1.12.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.0

--- a/tags.go
+++ b/tags.go
@@ -525,7 +525,6 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 	}
 
 	del := []string{}
-	add := []string{}
 
 	for _, oldTag := range ex {
 		d := true
@@ -543,28 +542,8 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 		}
 	}
 
-	for _, newTag := range tags {
-		a := true
-
-		for _, oldTag := range ex {
-			if oldTag == newTag {
-				a = false
-
-				break
-			}
-		}
-
-		if a {
-			add = append(add, newTag)
-		}
-	}
-
-	if len(add) == 0 && len(del) == 0 {
-		return 0, nil
-	}
-
 	mod := ModifyTags{
-		Add:    add,
+		Add:    tags,
 		Remove: del,
 	}
 
@@ -580,7 +559,7 @@ func (sc *SnowthClient) UpdateCheckTagsContext(ctx context.Context,
 		return 0, fmt.Errorf("unable to post tags update: %w", err)
 	}
 
-	return int64(len(add) + len(del)), nil
+	return int64(len(tags) + len(del)), nil
 }
 
 // encodeTags performs base64 encoding on tags when needed.

--- a/tags_test.go
+++ b/tags_test.go
@@ -535,7 +535,7 @@ func TestUpdateCheckTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if r != 1 {
-		t.Fatalf("expecting return: 1, got: %v", r)
+	if r != 2 {
+		t.Fatalf("expecting return: 2, got: %v", r)
 	}
 }


### PR DESCRIPTION
* upd: Changes the mechanism of UpdateCheckTags() to mitigate a race condition that can occur if check tags are being rapidly changed. It will now always attempts to add the full set of check tags being submitted rather than only the ones that snowth thinks do not already exist.