### PR TITLE
CIRC-9694: Implement PromQLError type for PromQL compatibility support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,12 +6,17 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.12.4] - 2023-02-21
+
+* upd: Adds a PromQLError type, which duplicates the PromQL response envelope,
+but also functions as a Go error type.
+
 ## [v1.12.3] - 2023-02-17
 
-* upd: Changes the mechanism of updating check tags to mitigate a race condition
-that can occur if check tags are being rapidly changed. Always attempts to add
-the full set of check tags being submitted rather than only the ones it snowth
-thinks do not already exist.
+* upd: Changes the mechanism of UpdateCheckTags() to mitigate a race condition
+that can occur if check tags are being rapidly changed. It will now always
+attempt to add the full set of check tags being submitted rather than only the
+ones that snowth thinks do not already exist.
 
 ## [v1.12.2] - 2023-02-17
 
@@ -440,6 +445,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.12.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.4
 [v1.12.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.3
 [v1.12.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.2
 [v1.12.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.1


### PR DESCRIPTION
* upd: Adds a PromQLError type, which duplicates the PromQL response envelope, but also functions as a Go error type.