### PR TITLE
CIRC-9872: Address issue causing client creation failure for single failing node

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,14 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
-## [v1.12.4] - 2023-02-21
+## [v1.13.0] - 2023-02-23
+
+* fix: Corrects a bug that could cause snowth client creation to fail if a
+single cluster node does not respond within the context timeout.
+* upd: Removes the Config.Discover option and the deprecated NewSnowthClient()
+function. These were not used and were supplanted by WatchAndUpdate()
+
+## [v1.12.5] - 2023-02-21
 
 * upd: Adds a PromQLError type, which duplicates the PromQL response envelope,
 but also functions as a Go error type.
@@ -445,6 +452,8 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.0
+[v1.12.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.5
 [v1.12.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.4
 [v1.12.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.3
 [v1.12.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,8 @@ to [Semantic Versioning](http://semver.org/) rules.
 * fix: Corrects a bug that could cause snowth client creation to fail if a
 single cluster node does not respond within the context timeout.
 * upd: Removes the Config.Discover option and the deprecated NewSnowthClient()
-function. These were not used and were supplanted by WatchAndUpdate()
+function. These were not used and were previously replaced by NewClient() and
+the WatchAndUpdate() functionality.
 
 ## [v1.12.5] - 2023-02-21
 

--- a/common.go
+++ b/common.go
@@ -27,45 +27,6 @@ func resolveURL(baseURL *url.URL, ref string) string {
 	return baseURL.ResolveReference(refURL).String()
 }
 
-// multiError values keep track of multiple errors.
-type multiError struct {
-	errs []error
-}
-
-// newMultiError initializes a new multiError value.
-func newMultiError() *multiError {
-	return &multiError{
-		errs: []error{},
-	}
-}
-
-// Add appends an error to the list of errors.
-func (me *multiError) Add(err error) {
-	if err != nil {
-		me.errs = append(me.errs, err)
-	}
-}
-
-// HasError returns whether the value contains any errors.
-func (me multiError) HasError() bool {
-	return len(me.errs) > 0
-}
-
-// String returns a string representation of the error value.
-func (me multiError) String() string {
-	es := []string{}
-	for _, err := range me.errs {
-		es = append(es, err.Error())
-	}
-
-	return strings.Join(es, "; ")
-}
-
-// Error implements the error interface for multiError values.
-func (me multiError) Error() string {
-	return me.String()
-}
-
 // encodeJSON create a reader of JSON data representing an interface.
 func encodeJSON(v interface{}) (io.Reader, error) {
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
* fix: Corrects a critical bug that could cause snowth client creation to fail if a single cluster node does not respond within the context timeout.
* upd: Removes the Config.Discover option and the deprecated NewSnowthClient() function. These were not used and were previously replaced by NewClient() and the WatchAndUpdate() functionality.