### PR TITLE
CIRC-9964: Implement deny hosts configuration item

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.2] - 2023-03-09
+
+* add: Adds a configuration item, DenyHosts, to allow a list of hosts to
+always be considered inactive, regardless of topology discovery.
+
 ## [v1.13.1] - 2023-02-23
 
 * upd: Modifies the PromQLResponse and PromQLError types to support more types
@@ -460,6 +465,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.2
 [v1.13.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.1
 [v1.13.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.0
 [v1.12.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.12.5

--- a/client.go
+++ b/client.go
@@ -222,6 +222,15 @@ func NewClient(ctx context.Context, cfg *Config,
 					return
 				}
 
+				for _, dh := range cfg.DenyHosts {
+					if url.Host == dh {
+						errCh <- fmt.Errorf("deny host found in servers: %s",
+							url.Host)
+
+						return
+					}
+				}
+
 				node := &SnowthNode{url: url}
 
 				stats, err := sc.GetStatsNodeContext(ctx, node)


### PR DESCRIPTION
* add: Adds a configuration item, DenyHosts, to allow a list of hosts to always be considered inactive, regardless of topology discovery.