### PR TITLE
CIRC-9980: Restore some quote processing to metric stream tags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](http://semver.org/) rules.
 ## [v1.13.3] - 2023-03-10
 
 * fix: Removes quote handling from the metric name parser. This handling is
-correct for tag queries, but not for cannonical name parsing.
+correct for tag queries, but not for canonical name parsing.
 
 ## [v1.13.2] - 2023-03-09
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.3] - 2023-03-10
+
+* fix: Removes quote handling from the metric name parser. This handling is
+correct for tag queries, but not for cannonical name parsing.
+
 ## [v1.13.2] - 2023-03-09
 
 * add: Adds a configuration item, DenyHosts, to allow a list of hosts to
@@ -465,6 +470,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.3
 [v1.13.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.2
 [v1.13.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.1
 [v1.13.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.4] - 2023-03-10
+
+* fix: Restores some quote handling for metric name parsing but corrects the
+bug that was causing removal of quotes from quoted values.
+
 ## [v1.13.3] - 2023-03-10
 
 * fix: Removes quote handling from the metric name parser. This handling is
@@ -470,6 +475,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.4
 [v1.13.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.3
 [v1.13.2]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.2
 [v1.13.1]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.1

--- a/metric.go
+++ b/metric.go
@@ -205,95 +205,17 @@ func (ms *metricScanner) scanTagName() (scanToken, string, string, error) {
 
 	var can bytes.Buffer
 
-	quoted := false
-
 loop:
 	for {
 		ch := ms.read()
 		switch ch {
-		case '"':
-			quoted = !quoted
-
-			if _, err := buf.WriteRune(ch); err != nil {
-				return tokenIllegal, "", "", fmt.Errorf(
-					"unable to write to tag name buffer: %w", err)
-			}
-
-			if _, err := can.WriteRune(ch); err != nil {
-				return tokenIllegal, "", "", fmt.Errorf(
-					"unable to write to tag name canonical buffer: %w", err)
-			}
-		case '\\':
-			if quoted { //nolint:nestif
-				ch2 := ms.read()
-				if ch2 == '"' || ch2 == '\\' {
-					if _, err := buf.WriteRune(ch2); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name canonical buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch2); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name canonical buffer: %w", err)
-					}
-				} else {
-					if err := ms.unread(); err != nil {
-						if _, err := buf.WriteRune(ch); err != nil {
-							return tokenIllegal, "", "", fmt.Errorf(
-								"unable to unread rune from tag name: %w", err)
-						}
-
-						if _, err := can.WriteRune(ch); err != nil {
-							return tokenIllegal, "", "", fmt.Errorf(
-								"unable to write to tag name canonical buffer: %w", err)
-						}
-					}
-
-					if _, err := buf.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name canonical buffer: %w", err)
-					}
-				}
-			} else {
-				if _, err := buf.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to tag name buffer: %w", err)
-				}
-
-				if _, err := can.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to tag name canonical buffer: %w", err)
-				}
-			}
 		case ':':
-			if !quoted {
-				if err := ms.unread(); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to unread to scan buffer: %w", err)
-				}
-
-				break loop
-			} else {
-				if _, err := buf.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to tag name buffer: %w", err)
-				}
-
-				if _, err := can.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to tag name canonical buffer: %w", err)
-				}
+			if err := ms.unread(); err != nil {
+				return tokenIllegal, "", "", fmt.Errorf(
+					"unable to unread to scan buffer: %w", err)
 			}
+
+			break loop
 		case rune(0): // EOF
 			break loop
 		default:
@@ -313,84 +235,18 @@ loop:
 }
 
 // scanTagValue attempts to read a tag value token from the scan buffer.
-func (ms *metricScanner) scanTagValue( //nolint:gocyclo
+func (ms *metricScanner) scanTagValue(
 	tt tagType,
 ) (scanToken, string, string, error) {
 	var buf, can bytes.Buffer
-
-	quoted := false
 
 loop:
 	for {
 		ch := ms.read()
 		switch ch {
-		case '"':
-			quoted = !quoted
-
-			if _, err := buf.WriteRune(ch); err != nil {
-				return tokenIllegal, "", "", fmt.Errorf(
-					"unable to write to tag name buffer: %w", err)
-			}
-
-			if _, err := can.WriteRune(ch); err != nil {
-				return tokenIllegal, "", "", fmt.Errorf(
-					"unable to write to canonical tag name buffer: %w", err)
-			}
-		case '\\':
-			if quoted { //nolint:nestif
-				ch2 := ms.read()
-				if ch2 == '"' || ch2 == '\\' {
-					if _, err := buf.WriteRune(ch2); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to canonical tag name buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch2); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to canonical tag name buffer: %w", err)
-					}
-				} else {
-					if err := ms.unread(); err != nil {
-						if _, err := buf.WriteRune(ch); err != nil {
-							return tokenIllegal, "", "", fmt.Errorf(
-								"unable to unread rune from tag name: %w", err)
-						}
-
-						if _, err := can.WriteRune(ch); err != nil {
-							return tokenIllegal, "", "", fmt.Errorf(
-								"unable to write to canonical tag name buffer: %w", err)
-						}
-					}
-
-					if _, err := buf.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to tag name buffer: %w", err)
-					}
-
-					if _, err := can.WriteRune(ch); err != nil {
-						return tokenIllegal, "", "", fmt.Errorf(
-							"unable to write to canonical tag name buffer: %w", err)
-					}
-				}
-			} else {
-				if _, err := buf.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to tag name buffer: %w", err)
-				}
-
-				if _, err := can.WriteRune(ch); err != nil {
-					return tokenIllegal, "", "", fmt.Errorf(
-						"unable to write to canonical tag name buffer: %w", err)
-				}
-			}
 		case ',', ']', '}':
-			if !quoted && (ch == ',' || (ch == ']' && tt == tagStreamTag) ||
-				(ch == '}' && tt == tagMeasurementTag)) {
+			if ch == ',' || (ch == ']' && tt == tagStreamTag) ||
+				(ch == '}' && tt == tagMeasurementTag) {
 				if err := ms.unread(); err != nil {
 					return tokenIllegal, "", "", fmt.Errorf(
 						"unable to unread to scan buffer: %w", err)
@@ -489,11 +345,6 @@ func (mp *MetricParser) parseTagSet(tt tagType) (string, []Tag, error) {
 			tag.Category = string(b)
 		}
 
-		if strings.HasPrefix(tag.Category, `"`) &&
-			strings.HasSuffix(tag.Category, `"`) {
-			tag.Category = strings.Trim(tag.Category, `"`)
-		}
-
 		canonical.WriteString(can)
 
 		if tok, lit = mp.s.scan(); tok != tokenColon {
@@ -527,11 +378,6 @@ func (mp *MetricParser) parseTagSet(tt tagType) (string, []Tag, error) {
 			}
 
 			tag.Value = string(b)
-		}
-
-		if strings.HasPrefix(tag.Value, `"`) &&
-			strings.HasSuffix(tag.Value, `"`) {
-			tag.Value = strings.Trim(tag.Value, `"`)
 		}
 
 		canonical.WriteString(can)

--- a/metric.go
+++ b/metric.go
@@ -306,7 +306,7 @@ loop:
 }
 
 // scanTagValue attempts to read a tag value token from the scan buffer.
-func (ms *metricScanner) scanTagValue( //nolint:gocyclo
+func (ms *metricScanner) scanTagValue(
 	tt tagType,
 ) (scanToken, string, string, error) {
 	var buf, can bytes.Buffer

--- a/metric_test.go
+++ b/metric_test.go
@@ -235,19 +235,19 @@ func TestMetricParser(t *testing.T) {
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah":blah]|MT{blah:"MTblah"}`,
+			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah":blah]|MT{blah:"|MTblah"}`,
+			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["b":"b"]|MT{b:"MTb"}|ST[a:b]|MT{c:d}`,
+			input: `testing|ST["b:|ST[]":b]|MT{b:",}:|MTb"}|ST[a:b]|MT{c:d}`,
 			numST: 2,
 			numMT: 2,
 			lit:   "testing",

--- a/metric_test.go
+++ b/metric_test.go
@@ -235,19 +235,19 @@ func TestMetricParser(t *testing.T) {
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
+			input: `testing|ST["blah":blah]|MT{blah:"MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["blah:|ST[]":blah]|MT{blah:",}:|MTblah"}`,
+			input: `testing|ST["blah":blah]|MT{blah:"|MTblah"}`,
 			numST: 1,
 			numMT: 1,
 			lit:   "testing",
 		},
 		{
-			input: `testing|ST["b:|ST[]":b]|MT{b:",}:|MTb"}|ST[a:b]|MT{c:d}`,
+			input: `testing|ST["b":"b"]|MT{b:"MTb"}|ST[a:b]|MT{c:d}`,
 			numST: 2,
 			numMT: 2,
 			lit:   "testing",


### PR DESCRIPTION
* fix: Restores some quote handling for metric name parsing but corrects the bug that was causing removal of quotes from quoted values.