### PR TITLE
CIRC-9934: Add support for PromQL fractional time seconds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.6] - 2023-03-14
+
+* upd: Adds support for fractional seconds for PromQL queries for compatibility.
+PromQL fractional seconds are truncated when converting to CAQL queries.
+
 ## [v1.13.5] - 2023-03-14
 
 * add: Adds support for PromQL instant queries.
@@ -479,6 +484,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.6
 [v1.13.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.5
 [v1.13.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.4
 [v1.13.3]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.3

--- a/promql.go
+++ b/promql.go
@@ -124,15 +124,15 @@ func (sc *SnowthClient) PromQLInstantQueryContext(ctx context.Context,
 
 	if query.Time != "" {
 		if t, err := time.Parse(time.RFC3339, query.Time); err != nil {
-			i, err := strconv.ParseInt(query.Time, 10, 64)
+			f, err := strconv.ParseFloat(query.Time, 64)
 			if err != nil {
 				return nil,
 					fmt.Errorf("invalid PromQL query: invalid time: %v",
 						query.Time)
 			}
 
-			q.End = i
-			q.Start = i - 1
+			q.End = int64(f)
+			q.Start = int64(f) - 1
 		} else {
 			q.End = t.Unix()
 			q.Start = t.Unix() - 1
@@ -267,14 +267,14 @@ func (sc *SnowthClient) PromQLRangeQueryContext(ctx context.Context,
 
 	if query.Start != "" {
 		if t, err := time.Parse(time.RFC3339, query.Start); err != nil {
-			i, err := strconv.ParseInt(query.Start, 10, 64)
+			f, err := strconv.ParseFloat(query.Start, 64)
 			if err != nil {
 				return nil,
 					fmt.Errorf("invalid PromQL range query: invalid start: %v",
 						query.Start)
 			}
 
-			q.Start = i
+			q.Start = int64(f)
 		} else {
 			q.Start = t.Unix()
 		}
@@ -282,14 +282,14 @@ func (sc *SnowthClient) PromQLRangeQueryContext(ctx context.Context,
 
 	if query.End != "" {
 		if t, err := time.Parse(time.RFC3339, query.End); err != nil {
-			i, err := strconv.ParseInt(query.End, 10, 64)
+			f, err := strconv.ParseFloat(query.End, 64)
 			if err != nil {
 				return nil,
 					fmt.Errorf("invalid PromQL range query: invalid end: %v",
 						query.End)
 			}
 
-			q.End = i
+			q.End = int64(f)
 		} else {
 			q.End = t.Unix()
 		}

--- a/promql_test.go
+++ b/promql_test.go
@@ -139,7 +139,7 @@ func TestPromQLInstantQuery(t *testing.T) {
 	res, err := sc.PromQLInstantQuery(&PromQLInstantQuery{
 		AccountID: "1",
 		Query:     "test",
-		Time:      "300",
+		Time:      "300.123",
 	}, node)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
* upd: Adds support for fractional seconds for PromQL queries for compatibility. PromQL fractional seconds are truncated when converting to CAQL queries.