### PR TITLE
CIRC-9935, CIRC-9936: Implement support for PromQL series & label queries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,15 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.7] - 2023-03-17
+
+* add: Adds PromQL support for series queries via PromQLSeriesQuery().
+* add: Adds PromQL support for label names queries via PromQLLabelQuery().
+* add: Adds PromQL support for label values queries via
+PromQLLabelValuesQuery().
+* add: Adds conversion of PromQL series selectors into IRONdb tag queries via
+ConvertSeriesSelector().
+
 ## [v1.13.6] - 2023-03-14
 
 * upd: Adds support for fractional seconds for PromQL queries for compatibility.
@@ -484,6 +493,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.7]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.7
 [v1.13.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.6
 [v1.13.5]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.5
 [v1.13.4]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.4

--- a/promql.go
+++ b/promql.go
@@ -645,6 +645,10 @@ func (sc *SnowthClient) PromQLSeriesQueryContext( //nolint:gocyclo,maintidx
 		terms = append(terms, mt)
 	}
 
+	if len(terms) == 0 {
+		return nil, fmt.Errorf("invalid PromQL series query: missing match[]")
+	}
+
 	q := "or("
 
 	for i, t := range terms {

--- a/promql.go
+++ b/promql.go
@@ -601,7 +601,8 @@ func (sc *SnowthClient) PromQLSeriesQuery(query *PromQLSeriesQuery,
 }
 
 // PromQLSeriesQueryContext is the context aware version of PromQLSeriesQuery.
-func (sc *SnowthClient) PromQLSeriesQueryContext(ctx context.Context, //nolint:gocyclo,maintidx
+func (sc *SnowthClient) PromQLSeriesQueryContext( //nolint:gocyclo,maintidx
+	ctx context.Context,
 	query *PromQLSeriesQuery,
 	nodes ...*SnowthNode,
 ) (*PromQLResponse, error) {

--- a/promql_test.go
+++ b/promql_test.go
@@ -146,7 +146,7 @@ func TestPromQLInstantQuery(t *testing.T) {
 	}
 
 	if res.Data == nil {
-		t.Fatalf("Expected data: 2, got: %v", res.Data)
+		t.Fatalf("Expected data, got: %v", res.Data)
 	}
 
 	res, err = sc.PromQLInstantQuery(&PromQLInstantQuery{
@@ -247,7 +247,7 @@ func TestPromQLRangeQuery(t *testing.T) {
 	}
 
 	if res.Data == nil {
-		t.Fatalf("Expected data: 2, got: %v", res.Data)
+		t.Fatalf("Expected data, got: %v", res.Data)
 	}
 
 	res, err = sc.PromQLRangeQuery(&PromQLRangeQuery{
@@ -269,5 +269,291 @@ func TestPromQLRangeQuery(t *testing.T) {
 
 	if res.Error != exp {
 		t.Errorf("Expected error: %v, got: %v", exp, res.Error)
+	}
+}
+
+func TestConvertSeriesSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		sel  string
+		exp  string
+	}{{
+		name: "series_selector",
+		sel:  `test{test="test"}`,
+		exp:  `and(__name:b"dGVzdA==",and(b"dGVzdA==":b"dGVzdA=="))`,
+	}, {
+		name: "series_selector_two",
+		sel:  `test{test="test",test1="test1"}`,
+		exp: `and(__name:b"dGVzdA==",and(b"dGVzdA==":b"dGVzdA=="),` +
+			`and(b"dGVzdDE=":b"dGVzdDE="))`,
+	}, {
+		name: "series_selector_not",
+		sel:  `test{test="test",test1!="test1"}`,
+		exp: `and(__name:b"dGVzdA==",and(b"dGVzdA==":b"dGVzdA=="),` +
+			`not(b"dGVzdDE=":b"dGVzdDE="))`,
+	}, {
+		name: "series_selector_regex",
+		sel:  `test{test=~"test",test1!~"test1"}`,
+		exp: `and(__name:b"dGVzdA==",and(b"dGVzdA==":b/dGVzdA==/),` +
+			`not(b"dGVzdDE=":b/dGVzdDE=/))`,
+	}}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := ConvertSeriesSelector(tt.sel)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if r != tt.exp {
+				t.Errorf("Expected query: %v, got: %v", tt.exp, r)
+			}
+		})
+	}
+}
+
+const promQLSeriesTestData = `[
+	{
+		"uuid": "3aa57ac2-28de-4ec4-aa3d-ed0ddd48fa4d",
+		"check_tags": [
+			"test:test",
+			"__check_id:1"
+		],
+		"metric_name": "test|ST[test1:test1]",
+		"type": "numeric,histogram",
+		"activity": [
+			[
+				1555610400,
+				1556588400
+			],
+			[
+				1556625600,
+				1561848300
+			]
+		],
+		"latest": {
+			"numeric": [
+				[1561848300000, 1]
+			]
+		},
+		"account_id": 1
+	}
+]`
+
+func TestPromQLSeriesQuery(t *testing.T) {
+	t.Parallel()
+
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request,
+	) {
+		if r.RequestURI == "/state" {
+			_, _ = w.Write([]byte(stateTestData))
+
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			_, _ = w.Write([]byte(statsTestData))
+
+			return
+		}
+
+		w.Header().Set("X-Snowth-Search-Result-Count", "1")
+		_, _ = w.Write([]byte(promQLSeriesTestData))
+
+		return
+	}))
+
+	defer ms.Close()
+
+	sc, err := NewClient(context.Background(),
+		&Config{Servers: []string{ms.URL}})
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+
+	res, err := sc.PromQLSeriesQuery(&PromQLSeriesQuery{
+		Match:     []string{"test"},
+		Start:     "0",
+		End:       "300",
+		AccountID: "1",
+	}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Data == nil {
+		t.Fatalf("Expected data, got: %v", res.Data)
+	}
+
+	dm, ok := res.Data.([]map[string]string)
+	if !ok {
+		t.Fatalf("Invalid type for result data: %T", res.Data)
+	}
+
+	if len(dm) < 1 {
+		t.Fatalf("Expected data length: 1, got: %v", len(dm))
+	}
+
+	if dm[0]["__name__"] != "test" {
+		t.Errorf("Expected __name__: test, got: %v", dm[0]["__name__"])
+	}
+
+	if dm[0]["test"] != "test" {
+		t.Errorf("Expected test: test, got: %v", dm[0]["test"])
+	}
+
+	if dm[0]["test1"] != "test1" {
+		t.Errorf("Expected test1: test1, got: %v", dm[0]["test1"])
+	}
+}
+
+func TestPromQLLabelQuery(t *testing.T) {
+	t.Parallel()
+
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request,
+	) {
+		if r.RequestURI == "/state" {
+			_, _ = w.Write([]byte(stateTestData))
+
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			_, _ = w.Write([]byte(statsTestData))
+
+			return
+		}
+
+		w.Header().Set("X-Snowth-Search-Result-Count", "1")
+		_, _ = w.Write([]byte(tagCatsValsTestData))
+
+		return
+	}))
+
+	defer ms.Close()
+
+	sc, err := NewClient(context.Background(),
+		&Config{Servers: []string{ms.URL}})
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+
+	res, err := sc.PromQLLabelQuery(&PromQLLabelQuery{
+		Match:     []string{"test"},
+		Start:     "0",
+		End:       "300",
+		AccountID: "1",
+	}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Data == nil {
+		t.Fatalf("Expected data, got: %v", res.Data)
+	}
+
+	ds, ok := res.Data.([]string)
+	if !ok {
+		t.Fatalf("Invalid type for result data: %T", res.Data)
+	}
+
+	if len(ds) != 3 {
+		t.Fatalf("Expected data length: 3, got: %v", len(ds))
+	}
+
+	if ds[0] != "__name__" {
+		t.Errorf("Expected data: __name__, got: %v", ds[0])
+	}
+
+	if ds[1] != "test" {
+		t.Errorf("Expected data: test, got: %v", ds[1])
+	}
+}
+
+func TestPromQLLabelValuesQuery(t *testing.T) {
+	t.Parallel()
+
+	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request,
+	) {
+		if r.RequestURI == "/state" {
+			_, _ = w.Write([]byte(stateTestData))
+
+			return
+		}
+
+		if r.RequestURI == "/stats.json" {
+			_, _ = w.Write([]byte(statsTestData))
+
+			return
+		}
+
+		w.Header().Set("X-Snowth-Search-Result-Count", "1")
+		_, _ = w.Write([]byte(tagCatsValsTestData))
+
+		return
+	}))
+
+	defer ms.Close()
+
+	sc, err := NewClient(context.Background(),
+		&Config{Servers: []string{ms.URL}})
+	if err != nil {
+		t.Fatal("Unable to create snowth client", err)
+	}
+
+	u, err := url.Parse(ms.URL)
+	if err != nil {
+		t.Fatal("Invalid test URL")
+	}
+
+	node := &SnowthNode{url: u}
+
+	res, err := sc.PromQLLabelValuesQuery("test",
+		&PromQLLabelQuery{
+			Match:     []string{"test"},
+			Start:     "0",
+			End:       "300",
+			AccountID: "1",
+		}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Data == nil {
+		t.Fatalf("Expected data, got: %v", res.Data)
+	}
+
+	ds, ok := res.Data.([]string)
+	if !ok {
+		t.Fatalf("Invalid type for result data: %T", res.Data)
+	}
+
+	if len(ds) != 2 {
+		t.Fatalf("Expected data length: 2, got: %v", len(ds))
+	}
+
+	if ds[0] != "test" {
+		t.Errorf("Expected data: test, got: %v", ds[0])
 	}
 }


### PR DESCRIPTION
* add: Adds PromQL support for series queries via PromQLSeriesQuery().
* add: Adds PromQL support for label names queries via PromQLLabelQuery().
* add: Adds PromQL support for label values queries via PromQLLabelValuesQuery().
* add: Adds conversion of PromQL series selectors into IRONdb tag queries via ConvertSeriesSelector().