### PR TITLE
CIRC-10033: Ensure PromQLMetadataQuery() returns valid PromQL types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.13.9] - 2023-03-31
+
+* fix: Ensures PromQLMetadataQuery() only returns metrics with valid PromQL
+types and that can be expressed as PromQL types.
+
 ## [v1.13.8] - 2023-03-21
 
 * add: Adds PromQL support for metadata queries via PromQLMetadataQuery().
@@ -497,6 +502,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.13.9]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.9
 [v1.13.8]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.8
 [v1.13.7]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.7
 [v1.13.6]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.6

--- a/promql.go
+++ b/promql.go
@@ -1127,10 +1127,20 @@ func (sc *SnowthClient) PromQLMetadataQueryContext(
 	for _, fti := range res.Items {
 		name := fti.MetricName
 
+		promType := ""
+
+		if strings.Contains(fti.Type, "histogram") {
+			promType = "histogram"
+		} else if strings.Contains(fti.Type, "numeric") {
+			promType = "gauge"
+		} else {
+			continue
+		}
+
 		m := map[string]string{
 			"__name":   name,
 			"__name__": name,
-			"type":     fti.Type,
+			"type":     promType,
 			"unit":     "",
 			"help":     "",
 		}

--- a/promql.go
+++ b/promql.go
@@ -1079,6 +1079,8 @@ func (sc *SnowthClient) PromQLMetadataQueryContext(
 		q = mt
 	}
 
+	q = "and(not(__type:text)," + q + ")"
+
 	if query.Limit != "" {
 		i, err := strconv.ParseInt(query.Limit, 10, 64)
 		if err != nil {

--- a/promql_test.go
+++ b/promql_test.go
@@ -619,8 +619,7 @@ func TestPromQLMetadataQuery(t *testing.T) {
 		t.Fatalf("Expected data length: 1, got: %v", len(dm))
 	}
 
-	if dm["test"][0]["type"] != "numeric,histogram" {
-		t.Errorf("Expected type: numeric,histogram, got: %v",
-			dm["test"][0]["type"])
+	if dm["test"][0]["type"] != "histogram" {
+		t.Errorf("Expected type: histogram, got: %v", dm["test"][0]["type"])
 	}
 }


### PR DESCRIPTION
* fix: Ensures PromQLMetadataQuery() only returns metrics with valid PromQL types and that can be expressed as PromQL types.