### PR TITLE
refactor!: CIRC-10299: Update FindTags() to return whether the results are an estimate

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,15 @@ to [Semantic Versioning](http://semver.org/) rules.
 
 ## [Next Release]
 
+## [v1.14.0] - 2023-05-19
+
+* refactor!: Modifies the FindTagsResult values returned by the FindTags()
+functions so that they do not include a separate FindCount value, but use the
+count and estimate fields on the FindTagsResult when the query is count only.
+* feat: Includes accurate values in FindTagsResult.Estimate when results
+from a FindTags() query return estimated results from IRONdb. This can be
+used to determine that a timeout occurred during processing by IRONdb.
+
 ## [v1.13.9] - 2023-03-31
 
 * fix: Ensures PromQLMetadataQuery() only returns metrics with valid PromQL
@@ -502,6 +511,7 @@ writing to histogram endpoints.
 any delay, once started. Created: 2019-03-12. Fixed: 2019-03-13.
 
 [Next Release]: https://github.com/circonus-labs/gosnowth
+[v1.14.0]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.14.0
 [v1.13.9]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.9
 [v1.13.8]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.8
 [v1.13.7]: https://github.com/circonus-labs/gosnowth/releases/tag/v1.13.7

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const tagsCountTestData = `{"count":22,"estimate":false}`
+const tagsCountTestData = `{"count":22,"estimate":true}`
 
 const getCheckTagsTestData = `{
 	"11223344-5566-7788-9900-aabbccddeeff":["test:test"]
@@ -100,7 +100,7 @@ func TestFindTagsJSON(t *testing.T) {
 	}
 }
 
-func TestFindTags(t *testing.T) { //nolint:gocyclo
+func TestFindTags(t *testing.T) { //nolint:gocyclo,maintidx
 	t.Parallel()
 
 	ms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
@@ -160,8 +160,12 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 		t.Fatal(err)
 	}
 
-	if res.Count != 1 {
-		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+	if res.Count != 22 {
+		t.Errorf("Expected result count: 22, got: %v", res.Count)
+	}
+
+	if !res.Estimate {
+		t.Errorf("Expected result estimate: true, got: %v", res.Estimate)
 	}
 
 	res, err = sc.FindTags(1, "test", &FindTagsOptions{
@@ -176,8 +180,12 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 		t.Fatal(err)
 	}
 
+	if res.Estimate {
+		t.Errorf("Expected result estimate: false, got: %v", res.Estimate)
+	}
+
 	if res.Count != 1 {
-		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+		t.Errorf("Expected result count: 1, got: %v", res.Count)
 	}
 
 	if len(res.Items) != 1 {
@@ -201,7 +209,7 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 	}
 
 	if res.Count != 1 {
-		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+		t.Errorf("Expected result count: 1, got: %v", res.Count)
 	}
 
 	if len(res.Items) != 1 {
@@ -233,7 +241,7 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 	}
 
 	if res.Items[0].Activity[1][1] != 1561848300 {
-		t.Fatalf("Expected activity timestamp: 1561848300, got %v",
+		t.Errorf("Expected activity timestamp: 1561848300, got %v",
 			res.Items[0].Activity[1][1])
 	}
 
@@ -243,7 +251,7 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 	}
 
 	if res.Count != 1 {
-		t.Fatalf("Expected result count: 1, got: %v", res.Count)
+		t.Errorf("Expected result count: 1, got: %v", res.Count)
 	}
 
 	if len(res.Items) != 1 {
@@ -279,7 +287,7 @@ func TestFindTags(t *testing.T) { //nolint:gocyclo
 	}
 
 	if res.Items[0].Activity[1][1] != 1561848300 {
-		t.Fatalf("Expected activity timestamp: 1561848300, got %v",
+		t.Errorf("Expected activity timestamp: 1561848300, got %v",
 			res.Items[0].Activity[1][1])
 	}
 }


### PR DESCRIPTION
* refactor!: Modifies the FindTagsResult values returned by the FindTags() functions so that they do not include a separate FindCount value, but use the count and estimate fields on the FindTagsResult when the query is count only.
* feat: Includes accurate values in FindTagsResult.Estimate when results from a FindTags() query return estimated results from IRONdb. This can be used to determine that a timeout occurred during processing by IRONdb.